### PR TITLE
feat: add OpenA2A branding to navbar

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -91,6 +91,15 @@ body {
 .nav-link:hover { color: var(--text); background: var(--surface-2); }
 .nav-link.active { color: var(--teal); background: rgba(6, 182, 212, 0.1); }
 
+.header-org {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 1rem;
+  transition: color 0.15s;
+}
+.header-org:hover { color: var(--teal); }
+
 .header-status {
   display: flex;
   align-items: center;

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <div class="header-brand">
       <img src="/favicon.svg" alt="" class="header-logo" width="28" height="28">
       <h1 class="header-title">DVAA</h1>
-      <span class="header-subtitle">Damn Vulnerable AI Agent</span>
+      <span class="header-subtitle">Damn Vulnerable AI Agent by <a href="https://opena2a.org" target="_blank" rel="noopener" class="header-org">OpenA2A</a></span>
     </div>
     <nav class="nav" id="nav">
       <a href="#agents" class="nav-link active" data-view="agents">Agents</a>


### PR DESCRIPTION
## Summary
- Add \"Damn Vulnerable AI Agent by **OpenA2A**\" subtitle in header
- OpenA2A links to opena2a.org, styled white/bold/larger

## Test plan
- [x] Visual check in browser