### PR TITLE
Replace Related Projects with ecosystem footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,11 +300,17 @@ We welcome contributions:
 - MCP/A2A protocol implementations
 - Documentation improvements
 
-## Related Projects
+## OpenA2A Ecosystem
 
-- [HackMyAgent](https://github.com/opena2a-org/hackmyagent) - Security scanner for AI agents
-- [OASB](https://oasb.ai) - OpenA2A Security Benchmark
-- [OpenA2A](https://github.com/opena2a-org/agent-identity-management) - Open-source security for AI agents
+| Project | What it does |
+|---------|-------------|
+| [**AIM**](https://github.com/opena2a-org/agent-identity-management) | Identity & access management for AI agents |
+| [**HackMyAgent**](https://github.com/opena2a-org/hackmyagent) | Security scanner — 147 checks, attack mode, auto-fix |
+| [**Secretless AI**](https://github.com/opena2a-org/secretless-ai) | Keep credentials out of AI context windows |
+| [**DVAA**](https://github.com/opena2a-org/damn-vulnerable-ai-agent) | Deliberately vulnerable AI agents for security training |
+| [**OASB**](https://oasb.ai) | Open Agent Security Benchmark |
+
+[Website](https://opena2a.org) · [Discord](https://discord.gg/uRZa3KXgEn) · [Email](mailto:info@opena2a.org)
 
 ## License
 
@@ -313,7 +319,3 @@ Apache-2.0 - For educational and authorized security testing only.
 ## Disclaimer
 
 DVAA is provided for educational purposes. The authors are not responsible for misuse. Always obtain proper authorization before testing systems you don't own.
-
----
-
-**Part of the [OpenA2A](https://github.com/opena2a-org/agent-identity-management) ecosystem** — open-source security for AI agents


### PR DESCRIPTION
## Summary

- Replace incomplete Related Projects section with standardized ecosystem table
- Links all 5 OpenA2A projects (AIM, HackMyAgent, Secretless AI, DVAA, OASB)
- Add website, Discord, and email links in consistent format
- Keep Disclaimer section intact

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all project links resolve
- [ ] Confirm Discord invite link works