### PR TITLE
Use separate DOCKERHUB_PAT for description updates

### DIFF
--- a/.github/workflows/docker-hub-description.yml
+++ b/.github/workflows/docker-hub-description.yml
@@ -21,7 +21,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
           repository: opena2a/dvaa
           readme-filepath: ./DOCKER_README.md
           short-description: "Damn Vulnerable AI Agent — intentionally vulnerable AI agents for security testing and red-teaming"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,7 +69,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
           repository: opena2a/dvaa
           readme-filepath: ./DOCKER_README.md
           short-description: "Damn Vulnerable AI Agent — intentionally vulnerable AI agents for security testing and red-teaming"


### PR DESCRIPTION
## Summary
- Switch `peter-evans/dockerhub-description` to use `DOCKERHUB_PAT` instead of `DOCKERHUB_TOKEN`
- The description API requires a PAT with **Read, Write, and Delete** scope
- Image pushes continue using `DOCKERHUB_TOKEN` (unchanged)

## Setup required
Add a `DOCKERHUB_PAT` secret to the repo:
1. Go to https://hub.docker.com/settings/security
2. Create a new PAT with **Read, Write, and Delete** permissions
3. Add it at https://github.com/opena2a-org/damn-vulnerable-ai-agent/settings/secrets/actions as `DOCKERHUB_PAT`

## Test plan
- [ ] Add the `DOCKERHUB_PAT` secret
- [ ] Merge this PR — the `docker-hub-description` workflow will trigger and update the Docker Hub page