### PR TITLE
Remove Ollama references, document OpenAI/Anthropic support

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -31,11 +31,14 @@ cd damn-vulnerable-ai-agent
 docker compose up
 ```
 
-To use a real LLM backend via Ollama:
+### Real LLM Testing
 
-```bash
-docker compose --profile llm up
-```
+The Prompt Playground supports testing with real LLMs by entering your API key directly in the UI:
+
+- **OpenAI** (GPT-4o) -- enter your OpenAI API key
+- **Anthropic** (Claude) -- enter your Anthropic API key
+
+No environment variables or external services needed. Simulated mode (default) works without any API keys.
 
 ## Web Dashboard
 
@@ -122,7 +125,6 @@ curl -X POST http://localhost:3020/a2a/message -H "Content-Type: application/jso
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DVAA_LLM_BACKEND` | `simulated` | LLM backend (`simulated` or `ollama`) |
 | `PORT_API_BASE` | `3001` | Starting port for API agents |
 | `PORT_MCP_BASE` | `3010` | Starting port for MCP servers |
 | `PORT_A2A_BASE` | `3020` | Starting port for A2A agents |

--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ docker compose up
 
 # Open the dashboard
 open http://localhost:9000
-
-# Optional: start with a real LLM via Ollama
-docker compose --profile llm up
 ```
 
 ### Node.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,19 +13,4 @@ services:
       - "3011:3011"
       - "3020:3020"
       - "3021:3021"
-    environment:
-      - DVAA_LLM_BACKEND=simulated
     restart: unless-stopped
-
-  ollama:
-    image: ollama/ollama:latest
-    profiles:
-      - llm
-    ports:
-      - "11434:11434"
-    volumes:
-      - ollama_data:/root/.ollama
-    restart: unless-stopped
-
-volumes:
-  ollama_data:

--- a/src/playground/engine.js
+++ b/src/playground/engine.js
@@ -513,8 +513,7 @@ export class PlaygroundEngine {
    * Create real LLM client (OpenAI or Anthropic)
    */
   createRealLLM(provider, apiKey, model) {
-    // Ollama doesn't require API key
-    if (provider !== 'ollama' && !apiKey) {
+    if (!apiKey) {
       console.warn('No API key provided, using simulator');
       return this.simulator;
     }


### PR DESCRIPTION
## Summary
- Removed all Ollama references from README, DOCKER_README, docker-compose.yml, and engine.js
- Ollama was never fully integrated -- engine.js only handles `openai` and `anthropic` providers, and `DVAA_LLM_BACKEND` was unused in application code
- Replaced Ollama docs with accurate Prompt Playground LLM documentation (OpenAI GPT-4o, Anthropic Claude)

## Test plan
- [x] Grep confirms zero Ollama/DVAA_LLM_BACKEND references remain
- [x] `docker compose up` still works (no breaking changes to default simulated mode)
- [x] Prompt Playground LLM selection unaffected (OpenAI/Anthropic paths unchanged in engine.js)