### PR TITLE
chore: link OpenA2A nav bar to meta repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **[OpenA2A](https://opena2a.org)**: [AIM](https://github.com/opena2a-org/agent-identity-management) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [OASB](https://github.com/opena2a-org/oasb) · [ARP](https://github.com/opena2a-org/arp) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
+> **[OpenA2A](https://github.com/opena2a-org/opena2a)**: [AIM](https://github.com/opena2a-org/agent-identity-management) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [OASB](https://github.com/opena2a-org/oasb) · [ARP](https://github.com/opena2a-org/arp) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
 
 # Damn Vulnerable AI Agent (DVAA)
 


### PR DESCRIPTION
## Summary
- Link OpenA2A references to the meta repo (github.com/opena2a-org/opena2a)

## Test plan
- [x] Build passes
- [x] No test failures