### PR TITLE
fix: install npm dependencies in Docker image (#29)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY package.json ./
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev --no-audit --no-fund
 COPY src/ ./src/
 COPY public/ ./public/
 EXPOSE 3000 3001 3002 3003 3004 3005 3006 3007 3008 3010 3011 3012 3013 3020 3021


### PR DESCRIPTION
## Summary
- Dockerfile copied `package.json` but never ran `npm install`, so the image had no `node_modules`. The container crashed on boot with `ERR_MODULE_NOT_FOUND: Cannot find package 'openai'` (reported in #29).
- Add `npm install --omit=dev --no-audit --no-fund` after copying `package.json` / `package-lock.json` so production deps are installed into the image.

Fixes #29

## Test plan
- [x] `docker build -t dvaa-test .` — 107 packages installed, image builds clean
- [x] `docker run --rm -p 3099:3000 dvaa-test` — container boots past the original ERR_MODULE_NOT_FOUND and prints the DVAA banner / sandbox init