### PR TITLE
ci(release): add minimal npm Trusted Publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      # Package has no build or test scripts (ships as pure JS + Docker).
+      # We install dependencies so the lockfile is validated, then publish.
+      - run: npm ci
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+
+      - name: Verify provenance on npm
+        run: |
+          deadline=$((SECONDS + 300))
+          while [ $SECONDS -lt $deadline ]; do
+            attestations=$(npm view "damn-vulnerable-ai-agent" dist.attestations --json 2>&1 || true)
+            if [ -n "$attestations" ] && [ "$attestations" != "null" ] && [ "$attestations" != "{}" ]; then
+              echo "Provenance verified for damn-vulnerable-ai-agent"
+              exit 0
+            fi
+            echo "Attestations not yet visible, retrying in 15s... (elapsed ${SECONDS}s)"
+            sleep 15
+          done
+          echo "::error::Provenance attestations missing from npm for damn-vulnerable-ai-agent after 5 minutes"
+          exit 1
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
New `.github/workflows/release.yml` publishes `damn-vulnerable-ai-agent` on `v*` tag push via npm Trusted Publishing (OIDC). Node 24, `id-token: write`, no `NPM_TOKEN` / `NODE_AUTH_TOKEN`. Matches the Stage 1 pattern shipped in opena2a-cli 0.8.24 + @opena2a/shared 0.1.2.

**Minimal workflow** — the dvaa package has no build or test scripts (ships as pure JS + Docker), so `release.yml` skips those phases and goes straight from `npm ci` (lockfile validation) to `npm publish --provenance --access public`. Docker publish path is unchanged by this PR. Post-publish `npm view dist.attestations` poll (5-min deadline) asserts SLSA v1 attestations are visible before the job exits green. GitHub Release auto-generated via `softprops/action-gh-release@v2`.

## Prerequisite (one-time, before first tag push)
Configure Trusted Publisher on npmjs.com for `damn-vulnerable-ai-agent`:
- Organization: `opena2a-org`
- Repository: `damn-vulnerable-ai-agent`
- Workflow filename: `release.yml`
- Environment: *(blank)*

First real tag push happens in a subsequent session after TP is configured. This PR does not tag.

## Pre-push quality gate — findings classified per [CPO-018]

8-phase `/pre-push-review` ran. Phases 4.5 / 5 / 6 / 7b skipped (no detection logic, CLI-only, CI-plumbing diff, no version bump). Phase 4 HMA `secure` on this branch reports **28 findings (5 CRITICAL / 12 HIGH / 11 MEDIUM). None are introduced by this diff** (48-line `release.yml` addition only).

DVAA is an adversarial-corpus repo by design (see [README](./README.md): "intentionally vulnerable AI agent platform"). Shipping under [CPO-018] *Adversarial-corpus repos — HMA pre-push gate policy* (CI-plumbing PRs ship with findings documented in the body).

### CRITICAL / HIGH classification

| # | Sev | Check | File | Classification |
|---|---|---|---|---|
| 1 | CRITICAL | SKILL-002 | `scenarios/skill-backdoor-install/vulnerable/deploy.skill.md` | Adversarial-corpus-intentional (curl\|sh backdoor fixture) |
| 2 | CRITICAL | SKILL-007 | `scenarios/skill-backdoor-install/vulnerable/deploy.skill.md` | Adversarial-corpus-intentional (ClickFix fixture) |
| 3 | CRITICAL | SKILL-010 | `scenarios/skill-backdoor-install/vulnerable/deploy.skill.md` | Adversarial-corpus-intentional (env-access fixture) |
| 4 | CRITICAL | CONFIG-004 | `scenarios/supply-chain-to-rce/vulnerable/.env` | Adversarial-corpus-intentional (AWS_ACCESS_KEY fixture) |
| 5 | CRITICAL | UNICODE-STEGO-001 | `src/playground/engine.test.js:125` | Runtime-intentional-by-design (playground unicode-stego test fixture) |
| 6 | HIGH | GIT-002 | `.gitignore` | Pre-existing hygiene (add `secrets.json`, `*.pem`, `*.key`) |
| 7 | HIGH | PROC-001 | `Dockerfile` | Pre-existing hygiene (non-root USER directive) |
| 8 | HIGH | SUPPLY-001 × 4 | `scenarios/*/vulnerable/*.skill.md` | Adversarial-corpus-intentional (missing publisher metadata is the attack) |
| 9 | HIGH | SUPPLY-004 × 4 | `scenarios/*/vulnerable/*.skill.md` | Adversarial-corpus-intentional (missing installed_hash is the attack) |
| 10 | HIGH | RAG-002 | `src/challenges/index.js:577` | **Scanner FP on educational prose** — `background:` field contains prose describing the RAG attack ("Retrieved content is inserted directly into the prompt without sanitization"); the scanner matched the string describing the vulnerability, not vulnerable code |
| 11 | HIGH | RAG-002 | `src/llm/tutor.js:45` | **Scanner FP on educational prose** — template literal describing DVAA agents' vulnerabilities; same FP class as #10 but on a backtick template literal |

MEDIUM findings (11) are all either adversarial-corpus-intentional (`scenarios/*` SKILL-001, SKILL-018, SUPPLY-002) or pre-existing hygiene (`package.json` AIM-001, `CLAUDE.md` DNA-001) — not reproduced here for brevity.

### Scanner FPs — likely resolved by unpublished HMA 793cfba

Findings #10 and #11 are RAG-002 hits on prose describing RAG attacks (not on vulnerable code). The HMA context-gate fix for RAG-002 on TS string literals shipped to `main` in commit 793cfba on 2026-04-22 (issues #108 / #109) but is not yet published — HMA is on publish HOLD per the strategic frame, batched into 0.18. These findings should be re-checked on 0.18:
- If RAG-002 no longer fires on `challenges/index.js:577` and `tutor.js:45`, 793cfba closes them and the context gate works for JS object-literal + template-literal strings as well as TS.
- If they still fire, this is a new bug class (scanner matches prose describing the attack, not vulnerable code) — file as HMA bug #11 for the next batch.

Not added to the 0.18 batch list yet — awaits 0.18 rescan to confirm whether 793cfba already covers them.

### Pre-existing repo hygiene follow-ups (not blocking this PR)

1. **Lockfile drift.** `package-lock.json` has `hackmyagent@0.6.1`; `package.json` says `^0.11.0`. `npm ci` currently fails with EUSAGE. This will block the first real tag push (workflow step 3 runs `npm ci`). Fix in a follow-up PR: `npm install` to resync, commit updated lockfile. Not touched here so this PR stays scoped to CI plumbing.
2. **Declare adversarial corpus paths in `CLAUDE.md`.** Per [CPO-018] follow-up, `dvaa/CLAUDE.md` should add a `## Adversarial corpus paths` section listing `scenarios/`, `src/playground/`, `src/challenges/`, `src/llm/tutor.js` as exempt paths so future pre-push reviews don't re-classify from scratch.

Precedent: opena2a Stage 1 PR #87 (squashed 82c76f7), oasb Stage 2 PR #11 (squashed b0d3f1e), secretless Stage 2 PR #56 (squashed 257be4d). First-pass-clean trend: 2-of-3 so far (oasb + secretless).

## Test plan
- [ ] Merge with no tag pushed — confirm release workflow does not run (tag-only trigger).
- [ ] Configure TP on npmjs.com (see Prerequisite).
- [ ] In a subsequent session, fix lockfile drift, bump patch, push `v0.7.5`.
- [ ] Confirm `npm view damn-vulnerable-ai-agent dist.attestations --json` returns non-empty with `predicateType` matching SLSA v1.