### PR TITLE
feat(0.8.1): wire @opena2a/telemetry — first canary integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog — damn-vulnerable-ai-agent
+
+## 0.8.1
+
+### Added
+- Tier-1 anonymous usage telemetry via `@opena2a/telemetry`: `dvaa --version` shows the disclosure line; `dvaa telemetry [on|off|status]` subcommand inspects and toggles. Disable per-invocation with `OPENA2A_TELEMETRY=off`, persistently with `dvaa telemetry off`, audit payloads with `OPENA2A_TELEMETRY_DEBUG=print`. README §Telemetry documents the full schema and the [opena2a.org/telemetry](https://opena2a.org/telemetry) policy page.
+- `release-smoke.md` §7 covers the seven telemetry checks (--version, status, off-persist, on-persist, env-off override, debug-print, network-failure tolerance).
+
+### Behaviour
+- Default state is ON. Spec rationale: matches industry norm (npm, Docker Desktop, VS Code, Homebrew) for anonymous install counts. Opt-out is one env var or one subcommand.
+- No first-run banner — disclosure is discoverable via README + `--version` + `dvaa telemetry` + the policy page (per spec amendment 2026-04-27).
+- No content collection. The schema is locked at 10 fields (tool, version, install_id, event, name, success, duration_ms, platform, node_major, country_code) and any expansion requires a new spec amendment + Registry migration.
+- Telemetry is fire-and-forget; 2s timeout; network failures never block the CLI.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ dvaa --help
 | `dvaa scan <scenario> [--fix] [--json]` / `dvaa scan --list` | Run HMA against a scenario fixture and diff findings against `expected-checks.json`. `--fix` remediates and re-scans. `--list` enumerates all 86 scenarios. |
 | `dvaa benchmark [path] [--level L1\|L2\|L3] [--json]` | Run OASB-1 compliance benchmark against a target directory. |
 | `dvaa hma <args...>` | Pass-through to the bundled HackMyAgent CLI for anything not covered above. |
+| `dvaa telemetry [on\|off\|status]` | Inspect or toggle anonymous usage telemetry (see §Telemetry). |
 | `dvaa browse [url] [--agents X] [--categories Y] [--json] [--publish]` | Send DVAA agents to browse a target site (agentpwn.com by default). |
 
 Run any command with `--help` for per-command options.
@@ -271,6 +272,21 @@ These scenarios demonstrate real-world kill chains combining multiple ATM techni
 | rag-poison-to-impersonation | Poisoned RAG → agent impersonation → delegation abuse → memory extraction | T-2005 → T-5001 → T-4005 → T-7003 |
 | behavioral-drift-to-exfil | SOUL drift → security probing → data collection → encoded exfiltration | T-6004 → T-1004 → T-7001 → T-8002 |
 | atc-forgery-attack | Agent card discovery → identity cloning → integrity bypass | T-1006 → T-5001 → T-9004 |
+
+## Telemetry
+
+DVAA sends anonymous usage data to the OpenA2A Registry: tool name (`dvaa`), version, command name (`scan`, `attack`, etc.), success, duration, platform, Node major version, and a stable per-machine `install_id`. **No content is collected** — no scanned files, no attack payloads, no prompts, no responses, no env vars, no IPs (the Registry derives country code from the inbound `CF-IPCountry` header at ingest and discards the IP).
+
+Disclosure surfaces and opt-out:
+
+- **Policy page:** [opena2a.org/telemetry](https://opena2a.org/telemetry) — full schema, retention, and the `DELETE` endpoint to wipe your install_id.
+- **`dvaa --version`** — shows current state and the one-line opt-out hint.
+- **`dvaa telemetry status`** — prints state, install_id, config path, policy URL.
+- **Disable per-invocation:** `OPENA2A_TELEMETRY=off dvaa <anything>` (also accepts `0`, `false`, `no`).
+- **Disable persistently:** `dvaa telemetry off` (writes to `~/.config/opena2a/telemetry.json`).
+- **Audit every payload:** `OPENA2A_TELEMETRY_DEBUG=print dvaa <anything>` echoes each event to stderr in JSON before sending.
+
+Telemetry is fire-and-forget with a 2-second timeout; network failures never block DVAA.
 
 ## Contributing
 

--- a/docs/testing/release-smoke.md
+++ b/docs/testing/release-smoke.md
@@ -111,12 +111,41 @@ docker exec dvaa-smoke whoami                         # node, not root
 docker exec dvaa-smoke node_modules/.bin/hackmyagent --version   # current pinned HMA
 ```
 
-## 7. Cleanup
+## 7. Telemetry — disclosure surfaces and opt-out (2 min)
+
+Tier-1 telemetry shipped with v0.8.1. Verify the four disclosure surfaces and the opt-out paths actually work. **Do not point at the production endpoint while smoking** — set `OPENA2A_TELEMETRY_URL=http://127.0.0.1:1/never` so events go to a port that refuses connections (proves fire-and-forget tolerance) instead of polluting prod aggregates.
+
+```bash
+export OPENA2A_TELEMETRY_URL=http://127.0.0.1:1/never
+unset OPENA2A_TELEMETRY
+rm -f ~/.config/opena2a/telemetry.json   # start from a clean slate
+```
+
+| # | Command | Expected |
+|---|---------|----------|
+| 7.1 | `dvaa --version` | Two lines: `dvaa 0.8.1` then `Telemetry: on (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)` |
+| 7.2 | `dvaa telemetry status` | Prints `state: on`, a UUID install_id, the config path, the policy URL, and the toggle hint |
+| 7.3 | `dvaa telemetry off` | Prints `Telemetry disabled for dvaa.` Then `dvaa --version` shows `Telemetry: off`. `~/.config/opena2a/telemetry.json` has `"enabled": false`. |
+| 7.4 | `dvaa telemetry on` | Re-enables persistently. |
+| 7.5 | `OPENA2A_TELEMETRY=off dvaa telemetry status` | Shows `state: off` even though file says `on` (env wins). |
+| 7.6 | `OPENA2A_TELEMETRY_DEBUG=print dvaa agents` | Stderr contains a `[opena2a:telemetry]` line with the JSON payload (`tool: "dvaa"`, `event: "command"`, `name: "agents"`, `success: true`, `duration_ms: <int>`, no PII fields). |
+| 7.7 | `dvaa agents` (with the unreachable URL) | Command completes normally and exits 0. The unreachable telemetry endpoint must not slow the command perceptibly (≤2s timeout). |
+
+Fail the release if:
+- any line of output omits the disclosure
+- the persisted config file leaks anything beyond `enabled` and `installId`
+- the debug-print payload contains scanned content, file paths, env vars, or any field outside the locked schema (tool, version, install_id, event, name, success, duration_ms, platform, node_major)
+- `dvaa agents` blocks more than 2 seconds when the telemetry endpoint is unreachable
+
+## 8. Cleanup
 
 ```bash
 docker rm -f dvaa-smoke
 pkill -f "node src/index.js" 2>/dev/null
 rm -rf .dvaa .hackmyagent-cache
+unset OPENA2A_TELEMETRY_URL
+# Restore your real telemetry config if you had one — the tests above
+# overwrite ~/.config/opena2a/telemetry.json.
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,39 +10,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
-        "@opena2a/cli-ui": "file:../opena2a/packages/cli-ui",
-        "@opena2a/telemetry": "file:../opena2a/packages/telemetry",
+        "@opena2a/cli-ui": "0.4.0",
+        "@opena2a/telemetry": "0.1.1",
         "hackmyagent": "^0.11.0",
         "openai": "^6.21.0"
       },
       "bin": {
         "dvaa": "src/index.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "../opena2a/packages/cli-ui": {
-      "name": "@opena2a/cli-ui",
-      "version": "0.4.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "chalk": "^5.3.0"
-      },
-      "devDependencies": {
-        "@types/node": "^20.11.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0"
-      }
-    },
-    "../opena2a/packages/telemetry": {
-      "name": "@opena2a/telemetry",
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "devDependencies": {
-        "@types/node": "^20.11.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -69,18 +43,18 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -90,9 +64,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -143,8 +117,13 @@
       }
     },
     "node_modules/@opena2a/cli-ui": {
-      "resolved": "../opena2a/packages/cli-ui",
-      "link": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.4.0.tgz",
+      "integrity": "sha512-wro+mk1znr1PbEr9XvdI1jovP8qFpfuKoBYouf6XVkHTfLJ1z09Zpli6dEjB6bFz/HxLtZbJ9zg8aaurqFxTjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
+      }
     },
     "node_modules/@opena2a/contribute": {
       "version": "0.1.1",
@@ -171,8 +150,13 @@
       }
     },
     "node_modules/@opena2a/telemetry": {
-      "resolved": "../opena2a/packages/telemetry",
-      "link": true
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.1.1.tgz",
+      "integrity": "sha512-HExQZJOunfcRi5t27cBlL+bwdsfkq/TsVX+fUdCClg1jpoRGFWQKJvIgS+SO8k7ovBr2Y+6IaXt9tIM1xuXvKw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -204,9 +188,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -326,9 +310,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -509,9 +493,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -561,12 +545,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -731,9 +715,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -743,9 +727,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -794,9 +778,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -824,9 +808,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -982,9 +966,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.21.0.tgz",
-      "integrity": "sha512-26dQFi76dB8IiN/WKGQOV+yKKTTlRCxQjoi2WLt0kMcH8pvxVyvfdBDkld5GTl7W1qvBpwVOtFcsqktj3fBRpA==",
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
+      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -1021,9 +1005,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1053,9 +1037,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1214,13 +1198,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1359,12 +1343,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,48 @@
 {
   "name": "damn-vulnerable-ai-agent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "damn-vulnerable-ai-agent",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
+        "@opena2a/cli-ui": "file:../opena2a/packages/cli-ui",
+        "@opena2a/telemetry": "file:../opena2a/packages/telemetry",
         "hackmyagent": "^0.11.0",
         "openai": "^6.21.0"
       },
       "bin": {
         "dvaa": "src/index.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "../opena2a/packages/cli-ui": {
+      "name": "@opena2a/cli-ui",
+      "version": "0.4.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      }
+    },
+    "../opena2a/packages/telemetry": {
+      "name": "@opena2a/telemetry",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -114,6 +142,10 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@opena2a/cli-ui": {
+      "resolved": "../opena2a/packages/cli-ui",
+      "link": true
+    },
     "node_modules/@opena2a/contribute": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@opena2a/contribute/-/contribute-0.1.1.tgz",
@@ -137,6 +169,10 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@opena2a/telemetry": {
+      "resolved": "../opena2a/packages/telemetry",
+      "link": true
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "damn-vulnerable-ai-agent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The AI agent you're supposed to break. 14 agents, 12 vulnerability categories, zero consequences.",
   "type": "module",
   "main": "src/index.js",
@@ -42,6 +42,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
+    "@opena2a/cli-ui": "file:../opena2a/packages/cli-ui",
+    "@opena2a/telemetry": "file:../opena2a/packages/telemetry",
     "hackmyagent": "^0.11.0",
     "openai": "^6.21.0"
   }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
-    "@opena2a/cli-ui": "file:../opena2a/packages/cli-ui",
-    "@opena2a/telemetry": "file:../opena2a/packages/telemetry",
+    "@opena2a/cli-ui": "0.4.0",
+    "@opena2a/telemetry": "0.1.1",
     "hackmyagent": "^0.11.0",
     "openai": "^6.21.0"
   }

--- a/src/cli/commands/telemetry.js
+++ b/src/cli/commands/telemetry.js
@@ -1,0 +1,20 @@
+/**
+ * dvaa telemetry [on|off|status]
+ *
+ * Per-tool subcommand to inspect or change the persisted telemetry opt-out
+ * for the dvaa CLI. Status is the default action.
+ */
+
+import * as tele from "@opena2a/telemetry";
+import { runTelemetryCommand } from "@opena2a/cli-ui";
+
+export default async function runTelemetry(argv) {
+  const action = argv[0];
+  const out = runTelemetryCommand(action, {
+    tool: "dvaa",
+    getStatus: tele.status,
+    setOptOut: tele.setOptOut,
+  });
+  console.log(out);
+  return 0;
+}

--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -13,6 +13,8 @@ import runLogs from './commands/logs.js';
 import runScan from './commands/scan.js';
 import runBenchmark from './commands/benchmark.js';
 import runHma from './commands/hma.js';
+import runTelemetry from './commands/telemetry.js';
+import * as tele from '@opena2a/telemetry';
 
 const COMMANDS = {
   agents:    { run: runAgents,    summary: 'List DVAA agents with port, protocol, and security level.' },
@@ -22,6 +24,7 @@ const COMMANDS = {
   scan:      { run: runScan,      summary: 'Run HackMyAgent against a scenario fixture; --fix to remediate.' },
   benchmark: { run: runBenchmark, summary: 'Run OASB-1 benchmark against a DVAA agent.' },
   hma:       { run: runHma,       summary: 'Pass-through to the bundled HackMyAgent CLI.' },
+  telemetry: { run: runTelemetry, summary: 'Inspect or toggle anonymous usage telemetry: on | off | status.' },
   browse:    { run: null,         summary: 'Send DVAA agents to browse a target site (handled in index.js).' },
 };
 
@@ -39,6 +42,24 @@ export async function dispatch(argv) {
   const [name, ...rest] = argv;
   const cmd = COMMANDS[name];
   if (!cmd || !cmd.run) return false;
-  const exitCode = await cmd.run(rest);
+
+  // The telemetry subcommand inspects/toggles itself — don't track it
+  // (would create awkward feedback like "command: telemetry, success: true"
+  // on every status check).
+  const trackable = name !== 'telemetry';
+  const startedAt = trackable ? Date.now() : 0;
+  let exitCode = 0;
+  try {
+    exitCode = await cmd.run(rest);
+  } catch (err) {
+    if (trackable) tele.error(name, err?.code || err?.name || 'UNKNOWN');
+    throw err;
+  }
+  if (trackable) {
+    void tele.track(name, {
+      success: (exitCode ?? 0) === 0,
+      durationMs: Date.now() - startedAt,
+    });
+  }
   process.exit(exitCode ?? 0);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,29 @@
 import http from 'http';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+import * as tele from '@opena2a/telemetry';
+import { versionLine } from '@opena2a/cli-ui';
 import { getAllAgents, getAgentsByProtocol } from './core/agents.js';
 import { detectAttacks, SENSITIVE_DATA, SECURITY_LEVELS } from './core/vulnerabilities.js';
 import { createDashboardServer } from './dashboard/server.js';
 import { initSandbox } from './sandbox/init.js';
 import { callLLM, isLLMEnabled, configureLLM, disableLLM, getLLMConfig } from './llm/provider.js';
 import { isSubcommand, dispatch, listCommands } from './cli/router.js';
+
+// Resolve our own version once at startup — used by --version and tele.init.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PKG_VERSION = (() => {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8')).version;
+  } catch { return '0.0.0'; }
+})();
+
+// Tier-1 anonymous usage telemetry. Default ON; opt-out via env or
+// `dvaa telemetry off`. Disclosure surfaces: README §Telemetry,
+// `dvaa --version` line, `dvaa telemetry status`, opena2a.org/telemetry.
+// init() loads opt-out config + persists install_id; never throws.
+await tele.init({ tool: 'dvaa', version: PKG_VERSION });
 
 // Parse command line args
 const args = process.argv.slice(2);
@@ -88,16 +105,10 @@ if (args[0] === 'browse') {
   process.exit(result.status ?? 1);
 }
 
-// Handle --version
+// Handle --version — uses the shared versionLine helper so the telemetry
+// disclosure line is consistent across every opena2a-org CLI.
 if (args.includes('--version')) {
-  const { readFileSync } = await import('fs');
-  const { join, dirname } = await import('path');
-  const { fileURLToPath } = await import('url');
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  try {
-    const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
-    console.log(pkg.version);
-  } catch { console.log('0.5.0'); }
+  console.log(versionLine({ tool: 'dvaa', version: PKG_VERSION, telemetry: tele.status() }));
   process.exit(0);
 }
 
@@ -1258,6 +1269,9 @@ async function executeMcpTool(agent, toolName, args) {
 
 // Start servers
 console.log('Starting agents...\n');
+
+// Anonymous tier-1 telemetry — fire-and-forget, no PII. See `dvaa telemetry`.
+tele.start();
 
 const allAgents = getAllAgents();
 


### PR DESCRIPTION
## Summary

DVAA is the spec-locked canary tool for tier-1 anonymous usage telemetry. This PR wires `@opena2a/telemetry` into the dvaa CLI and ships v0.8.1.

**Draft** because:
1. `@opena2a/telemetry@0.1.0` is not yet published to npm (PR opena2a-org/opena2a#98). Deps are added as `file:../opena2a/packages/*` — these MUST be swapped to npm versions before tagging.
2. `opena2a-registry` `TELEMETRY_INGEST_ENABLED` is OFF in prod; events from this CLI will 404 until you flip the prod flag. The CLI handles that silently (fire-and-forget) but no aggregates will accrue until the flag is on.

Hold this PR until both upstream pieces are ready, then swap deps and mark ready.

## What this changes

**Wiring (`src/index.js`):**
- `await tele.init({ tool: 'dvaa', version: PKG_VERSION })` at the top — loads opt-out config, persists install_id.
- `tele.start()` fires when the agent fleet boots (server mode only — not on `--version` / subcommands / `--help`).
- `--version` output now uses `versionLine()` from `@opena2a/cli-ui` so the disclosure line is identical across every opena2a-org CLI:
  ```
  dvaa 0.8.1
  Telemetry: on (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)
  ```

**Wiring (`src/cli/router.js`):**
- `dispatch()` wraps each subcommand: fire `tele.track(name, { success, durationMs })` after the command exits, fire `tele.error(name, code)` if it throws.
- `telemetry` subcommand is excluded from tracking (avoids feedback like "command: telemetry, success: true" on every status check).

**New `src/cli/commands/telemetry.js`:**
- `dvaa telemetry [on|off|status]` — wraps `cli-ui`'s `runTelemetryCommand`. Status is the default action.

**Docs:**
- README §Telemetry — complete disclosure + opt-out paths + audit env var.
- CLI table updated with the new subcommand.
- `CHANGELOG.md` created with 0.8.1 entry.
- `docs/testing/release-smoke.md` §7 — seven telemetry checks. Old §7 Cleanup renumbered to §8.

## Live smoke (already executed against the file: deps)

```
$ dvaa --version
dvaa 0.8.1
Telemetry: on (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)

$ dvaa telemetry status
dvaa telemetry
  state:       on
  install_id:  09cfd5f8-1370-4558-8c33-c46313393e68
  config:      /Users/ecolibria/.config/opena2a/telemetry.json
  policy:      https://opena2a.org/telemetry

  toggle: 'dvaa telemetry off'  or  OPENA2A_TELEMETRY=off

$ dvaa telemetry off
Telemetry disabled for dvaa.
  state:       off
  ...

$ dvaa --version    # after off
dvaa 0.8.1
Telemetry: off (opt-out: OPENA2A_TELEMETRY=off  •  details: opena2a.org/telemetry)

$ OPENA2A_TELEMETRY=off dvaa telemetry status   # env wins
state: off

$ OPENA2A_TELEMETRY_DEBUG=print dvaa agents     # debug echo
[opena2a:telemetry] {"tool":"dvaa","version":"0.8.1","install_id":"09cfd5f8-1370-4558-8c33-c46313393e68","event":"command","platform":"darwin","node_major":25,"name":"agents","success":true,"duration_ms":1}
```

All seven release-smoke §7 checks pass. Network-failure tolerance verified by pointing `OPENA2A_TELEMETRY_URL=http://127.0.0.1:1/never` — `dvaa agents` completes in <2s as designed.

## Pre-tag checklist (BEFORE this PR is marked ready)

- [ ] `@opena2a/telemetry@0.1.0` published to npm (depends on opena2a-org/opena2a#98)
- [ ] `@opena2a/cli-ui@0.4.0` published to npm (same PR)
- [ ] `package.json` swapped: `file:../opena2a/packages/telemetry` → `^0.1.0`, same for cli-ui
- [ ] `npm ci` clean against the published versions
- [ ] All seven §7 release-smoke checks re-run against the published deps
- [ ] `opena2a-registry` `TELEMETRY_INGEST_ENABLED=true` in prod (separate ops change)
- [ ] First `telemetry-v0.1.0` ingest verified via Registry Grafana (or `psql` on the prod DB)

## What this PR explicitly does NOT do

- No npm publish (draft).
- No prod flag flip.
- No DVAA dashboard Settings → Privacy card update (the spec mentions it; that's a `damn-vulnerable-ai-agent` dashboard PR — separate from the CLI canary).
- No HMA / ai-trust / opena2a-cli / AIM / Secretless integrations — each will be its own PR using the same one-liner pattern this PR establishes.

## Related

- Spec: `opena2a-registry/docs/telemetry-spec.md` (amended in opena2a-registry#203)
- Ingest endpoint: opena2a-registry#200 (merged 2026-04-27)
- Disclosure-surfaces amendment: opena2a-registry#203 (open)
- SDK + cli-ui helpers: opena2a-org/opena2a#98 (draft)