### PR TITLE
fix(0.8.2): await tele.flush() so subcommand telemetry events land

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — damn-vulnerable-ai-agent
 
+## 0.8.2
+
+### Fixed
+- Subcommand telemetry events (`dvaa agents`, `dvaa scan`, etc.) were silently lost because the dispatcher fired `tele.track()` and immediately called `process.exit()`, killing Node before the HTTP request flushed. Discovered during prod canary verification — the curl probe landed in the Registry but the actual CLI did not. Fix: bump to `@opena2a/telemetry@0.1.2` (adds `flush()` and a `beforeExit` drain) and `await tele.flush()` in the dispatcher before exit. Per-event 2s timeout unchanged — `dvaa <cmd>` never hangs longer than that.
+
+### Note
+- v0.8.1 was tagged but the npm publish failed (Trusted Publisher not yet configured for `damn-vulnerable-ai-agent`). v0.8.2 supersedes it; users should install 0.8.2 directly.
+
 ## 0.8.1
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "damn-vulnerable-ai-agent",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "damn-vulnerable-ai-agent",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
         "@opena2a/cli-ui": "0.4.0",
-        "@opena2a/telemetry": "0.1.1",
+        "@opena2a/telemetry": "0.1.2",
         "hackmyagent": "^0.11.0",
         "openai": "^6.21.0"
       },
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@opena2a/telemetry": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.1.1.tgz",
-      "integrity": "sha512-HExQZJOunfcRi5t27cBlL+bwdsfkq/TsVX+fUdCClg1jpoRGFWQKJvIgS+SO8k7ovBr2Y+6IaXt9tIM1xuXvKw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@opena2a/telemetry/-/telemetry-0.1.2.tgz",
+      "integrity": "sha512-lMbNtwDfrXvrPWyEMXBY3ttU/RXWhQ2/xzSfCaosVvujFbqxtWuyq8YY725IEpQ9owa7uJ+PCp4mkxZ8UKW3wA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "damn-vulnerable-ai-agent",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The AI agent you're supposed to break. 14 agents, 12 vulnerability categories, zero consequences.",
   "type": "module",
   "main": "src/index.js",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
     "@opena2a/cli-ui": "0.4.0",
-    "@opena2a/telemetry": "0.1.1",
+    "@opena2a/telemetry": "0.1.2",
     "hackmyagent": "^0.11.0",
     "openai": "^6.21.0"
   }

--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -60,6 +60,11 @@ export async function dispatch(argv) {
       success: (exitCode ?? 0) === 0,
       durationMs: Date.now() - startedAt,
     });
+    // process.exit() does NOT trigger Node's beforeExit hook, so the SDK's
+    // natural drain doesn't fire here. Flush explicitly so the in-flight
+    // POST has time to land. flush() is bounded by the SDK's 2s per-event
+    // timeout — never hangs the CLI longer than that.
+    await tele.flush();
   }
   process.exit(exitCode ?? 0);
 }


### PR DESCRIPTION
Subcommand telemetry events were silently lost in 0.8.1 because dispatch() does `void tele.track(...)` then `process.exit()` — Node kills the process before fetch() flushes. Discovered during prod canary verification.

Bumps to @opena2a/telemetry@0.1.2 (which adds flush() + beforeExit drain) and adds `await tele.flush()` before process.exit() in the dispatcher.

Verified: `dvaa agents` event landed in prod tool_usage_events at 2026-04-27 13:37:52.

Note: v0.8.1 tag exists but never published to npm (Trusted Publisher not configured for damn-vulnerable-ai-agent yet). v0.8.2 supersedes.