### PR TITLE
fix(telemetry): treat exit 1 as success (attack demo ran ≠ failure)

### DIFF
--- a/src/cli/router.js
+++ b/src/cli/router.js
@@ -57,7 +57,12 @@ export async function dispatch(argv) {
   }
   if (trackable) {
     void tele.track(name, {
-      success: (exitCode ?? 0) === 0,
+      // Exit 1 = scenario triggered (dvaa's job is to demonstrate the
+      // attack, exit 1 signals "demo ran, attack landed"); exit >=2 is
+      // a real crash. Matches @opena2a/telemetry.successFromExitCode
+      // (post-0.2.0) which will replace this inline check once the
+      // dep pin bumps.
+      success: (exitCode ?? 0) <= 1,
       durationMs: Date.now() - startedAt,
     });
     // process.exit() does NOT trigger Node's beforeExit hook, so the SDK's


### PR DESCRIPTION
## Summary

DVAA's purpose is to demonstrate attacks against AI agents. Exit 1 typically means the attack scenario fired or the demo executed its negative-case path — i.e. dvaa worked. The dispatcher at `src/cli/router.js:60` was treating exit 1 as failure.

Combined with the SDK-level `install_id` rotation bug (fixed in `opena2a#144` as `@opena2a/telemetry@0.2.0`), this produced the most striking signal in the production `/admin/cli-usage` dashboard: **47 unique installs from 67 events** (Apr 27 – May 11). Roughly 70% of invocations got a fresh install_id, dramatically overstating user count. The SDK fix addresses the install_id half; this PR fixes the success-heuristic half.

Change `(exitCode ?? 0) === 0` → `(exitCode ?? 0) <= 1`. Exit ≥ 2 still records as failure.

## Companion PRs

- opena2a#144 — `@opena2a/telemetry@0.2.0` adds the centralised `successFromExitCode()` helper AND fixes the install_id container-instability bug. DVAA picks up the install_id fix on its next telemetry pin bump.
- hackmyagent#174, secretless-ai#71, ai-trust#41 — same one-line dispatcher fix.

## Test plan

- [x] `node --check src/cli/router.js` clean
- [x] No test script in this repo (DVAA is a runtime attack demo, not a unit-tested library)
- [x] Diff is 1 functional line (`=== 0` → `<= 1`) with comment
- [x] `hackmyagent secure --ci` self-scan — by design this scores 1/100 with findings throughout `scenarios/*/vulnerable/`. **0 findings in `src/cli/router.js` (the file this PR touches).** The adversarial-fixture path findings are intentional and pre-existing on main.

Audit doc: `~/workspace/opena2a-org/todo/2026-05-10-cli-telemetry-anomalies.md`