### PR TITLE
chore(release): bump version to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "damn-vulnerable-ai-agent",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "The AI agent you're supposed to break. 14 agents, 12 vulnerability categories, zero consequences.",
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
## Summary

Telemetry-fix release. PRs #38 (await flush) and #39 (exit-code-1-as-success) are already merged on main; this branch bumps `package.json` 0.8.2 → 0.8.3. Tag push triggers GHA OIDC publish.

USER_VISIBLE_IMPACT: dvaa 0.8.3 — install_id is now stable across container restarts (was randomizing on each run in dvaa's primary deploy surface, producing 47 unique installs from 67 events). Combined with the success-heuristic fix (exit 1 with attack-demo-ran = success), telemetry now reflects real user behaviour. User authorized 2026-05-12.

## Changes
- `package.json` 0.8.2 → 0.8.3

## Test plan
- [x] Pre-push 8-phase review — PASS (Phase 4 N/A: dvaa is intentionally vulnerable by design; the entire repo is a security training lab — the 27 HIGH + 12 CRITICAL HMA findings are *the product*, not regressions. None are introduced or modified by this diff.)
- [ ] Post-merge: tag `v0.8.3` and verify GHA OIDC publish + SLSA v1 attestation