### PR TITLE
docs: add STATUS.md (reference-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 > **[OpenA2A](https://github.com/opena2a-org/opena2a)**: [CLI](https://github.com/opena2a-org/opena2a) · [HackMyAgent](https://github.com/opena2a-org/hackmyagent) · [Secretless](https://github.com/opena2a-org/secretless-ai) · [AIM](https://github.com/opena2a-org/agent-identity-management) · [Browser Guard](https://github.com/opena2a-org/AI-BrowserGuard) · [DVAA](https://github.com/opena2a-org/damn-vulnerable-ai-agent)
 
+[![Status: reference-only](https://img.shields.io/badge/status-reference--only-blue)](./STATUS.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Docker Hub](https://img.shields.io/docker/pulls/opena2a/dvaa)](https://hub.docker.com/r/opena2a/dvaa)
 [![OASB Compatible](https://img.shields.io/badge/OASB-1.0-teal)](https://oasb.ai)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,22 @@
+# Status: reference-only
+
+**Stage:** reference-only
+**Maintenance horizon:** actively maintained through 2026-12-31, status reviewed quarterly
+**Maintainer wanted:** no
+
+## Stage rationale
+
+DVAA is an intentionally vulnerable AI agent platform used for security training, red-teaming, and validating security tools. It is the "DVWA of AI agents" and is **not intended for production deployment**. Running DVAA exposes the host to real exploitation vectors by design.
+
+## Stage definitions
+
+- **stable**: production-ready, semver honored, breaking changes documented, security patches triaged within 24 hours.
+- **beta**: feature-complete or near, breaking changes possible with notice, actively developed.
+- **experimental**: early stage, breaking changes expected, use at your own risk.
+- **reference-only**: spec or reference implementation, not intended for production use.
+
+## Status changes
+
+| Date | Stage | Reason |
+|---|---|---|
+| 2026-05-24 | reference-only | initial STATUS.md (org lifecycle introduction). DVAA is a training/red-team platform, not a production-grade tool. |


### PR DESCRIPTION
## Summary

Adds a top-level `STATUS.md` and a status-line badge to the README header. Part of the org-wide STATUS sweep so downstream consumers can read repo lifecycle at a glance.

Stage: **reference-only**. DVAA is intentionally vulnerable; it's a training/red-team platform, not production code.

## What changed

- `STATUS.md` (new): stage, maintenance horizon, maintainer-wanted flag, stage definitions, status-change log
- `README.md`: status badge in the existing badge cluster

## Scope

Part of the 16-repo non-honey sweep. The four honey-fleet bait repos (agent-hardening-guide, mcp-security-checklist, ai-credential-safety, a2a-security-examples) are intentionally excluded.

## Test plan

- [x] Pre-push gate passed (no build/test/lint scripts; docs-only phases skipped per skill)
- [x] STATUS.md renders correctly on GitHub
- [x] Badge links to STATUS.md