### PR TITLE
Cloud-mode AIM reporter: live dashboard view of RAGBot-AIM enforcement

### DIFF
--- a/DEMO_BUILD.md
+++ b/DEMO_BUILD.md
@@ -79,6 +79,67 @@ Flags:
 - `--json` Machine-readable output (for CI piping).
 - `--verbose` Includes raw chat responses and the full canary hit log.
 
+## Cloud mode (live AIM dashboard view)
+
+Default mode is local-first: aim-core stores the agent's Ed25519 identity, capability policy, audit log, and trust score on disk under `.dvaa-aim/<agent.id>/`. The `dvaa demo aim-ab` runner shows the denied event in CLI but there's no dashboard.
+
+Cloud mode adds a fire-and-forget mirror of each enforcement decision to an AIM server, where the agent is registered and the verification events appear in the dashboard UI. The local enforcement decision remains authoritative; the cloud post is best-effort and never blocks the request.
+
+**Bring up a local AIM stack and register the agent (one-shot):**
+
+```bash
+# From the dvaa repo root:
+./docs/demo/setup-aim-local.sh
+```
+
+The script will:
+1. `docker compose up` the 4-service AIM stack (postgres + redis + backend + frontend) in the sibling `agent-identity-management/` repo
+2. Generate `.env` with shell-safe random secrets for postgres / redis / JWT / keyvault (re-uses existing if present)
+3. Add a `docker-compose.override.yml` that remaps aim-postgres to host port 5433 (so it coexists with a local postgres on 5432)
+4. Seed a local admin user (`admin@opena2a.org` / `AIM2025!Secure`) via direct SQL using a bcrypt hash from migration 072
+5. Log in as that admin to capture a JWT
+6. Generate DVAA's Ed25519 identity for `ragbot-aim` (or reuse if `.dvaa-aim/ragbot-aim/identity.json` exists)
+7. Register the agent against the local backend with that public key and capabilities `rag:read, chat:respond`
+8. Print the env vars to copy into the next `dvaa --api` invocation
+
+**Local-only credentials, do not use in production.** The admin password is the DVAA-CTF default and is documented publicly; the script will refuse to run if it can detect a public-facing backend endpoint (TODO: that detection isn't in yet — for now just don't point it at a real cloud).
+
+**Run the demo with cloud reporting on:**
+
+```bash
+# Terminal 1 — DVAA fleet with cloud env set
+export AIM_SERVER_URL=http://localhost:8080
+export AIM_API_KEY=not_required_for_local_verifications
+export DVAA_AIM_CLOUD_AGENT_ID=<uuid the setup script printed>
+dvaa --api
+
+# Terminal 2 — the demo runner
+dvaa demo aim-ab
+```
+
+After the demo finishes, open http://localhost:3000, log in (`admin@opena2a.org` / `AIM2025!Secure`), navigate to Agents → see `dvaa-ragbot-aim` registered, navigate to Verification Events → see two events (one for each `dvaa demo aim-ab` run, with `action_type: http:post`, `status: success`, agent's trust score, Ed25519 signature on the request body).
+
+This is the SVCC conversion-funnel visual. Show the CLI demo for proof, then click into the dashboard to show the registered agent + audit trail. The talk pitch is "AIM denied this specific http:post because it's outside the agent's grant" — keep the claim narrow per the Scope section above.
+
+**Cloud-mode contract (so future maintainers don't re-derive it):**
+
+The reporter implements the Python SDK's `verify_capability` wire format (`aim_sdk/client.py:504-620`). One POST per enforcement decision to `/api/v1/sdk-api/verifications` with:
+- Body: `{agentId, capability, resource, context, timestamp, signature, publicKey, enforcementResult}`
+- Signature: Ed25519 over the canonical signature payload `{action_type, agent_id, context, resource, timestamp}`, JSON-serialized with sorted keys and Python's default separators (`', '` and `': '`) — see `src/aim-cloud-reporter.js pythonJsonStringify()`
+- Auth: NO bearer header. The Ed25519 signature in the body IS the auth (server `Ed25519AgentMiddleware` verifies against the agent's registered public key). The `X-API-Key` header is sent if `AIM_API_KEY` is set, but the verifications endpoint ignores it.
+
+**Tear down the local AIM stack when done:**
+
+```bash
+docker compose \
+  -f ../agent-identity-management/docker-compose.quickstart.yml \
+  -f ../agent-identity-management/docker-compose.override.yml \
+  --env-file ../agent-identity-management/.env \
+  down
+```
+
+Or `down -v` to also wipe the postgres volume (you'll need to re-seed the admin on next bring-up).
+
 ## How to run the AgentPwn showcase
 
 Same target URL DVAA documents in its main README; the 15th agent slots into the standard `dvaa browse` enumeration:

--- a/docs/demo/setup-aim-local.sh
+++ b/docs/demo/setup-aim-local.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# One-shot bring-up of a local AIM stack and registration of DVAA's
+# RAGBot-AIM agent against it.
+#
+# What it does:
+#   1. Brings up the 4-service AIM docker-compose stack (postgres + redis +
+#      backend + frontend) in agent-identity-management/
+#   2. Seeds a local admin user (admin@opena2a.org / AIM2025!Secure)
+#   3. Generates DVAA's Ed25519 identity for ragbot-aim via @opena2a/aim-core
+#   4. Registers the agent against the local AIM backend with that public key
+#   5. Prints the env vars to copy into `dvaa --api` so cloud reporting fires
+#
+# After this script, log into http://localhost:3000 as
+#   admin@opena2a.org / AIM2025!Secure
+# and you'll see dvaa-ragbot-aim registered + the verification events that
+# land each time `dvaa demo aim-ab` runs.
+#
+# LOCAL DEMO ONLY. The admin password is the legacy DVAA-CTF default and is
+# documented publicly. DO NOT use this script against any AIM stack reachable
+# from the public internet.
+
+set -euo pipefail
+
+DVAA_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+AIM_ROOT="${AIM_ROOT:-$DVAA_ROOT/../agent-identity-management}"
+ADMIN_EMAIL="admin@opena2a.org"
+ADMIN_PASSWORD="AIM2025!Secure"
+# bcrypt cost-12 hash of "AIM2025!Secure" (from agent-identity-management
+# migration 072 — the legacy DVAA-default-admin seed). Reused here so the
+# script doesn't depend on htpasswd / python bcrypt / etc.
+ADMIN_PW_HASH='$2a$12$UbRtBE0U9Ry36Bdl04YWDuXe3lIw14aZaxQ8B6bbA4P7peLRski66'
+BACKEND_URL="http://localhost:8080"
+DASHBOARD_URL="http://localhost:3000"
+
+step() { printf "\n\033[1;36m==> %s\033[0m\n" "$*"; }
+ok()   { printf "    \033[1;32m✓\033[0m %s\n" "$*"; }
+err()  { printf "    \033[1;31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+step "Pre-flight"
+[[ -d "$AIM_ROOT" ]] || err "AIM_ROOT not found: $AIM_ROOT (set AIM_ROOT env var to the agent-identity-management clone path)"
+[[ -f "$AIM_ROOT/docker-compose.quickstart.yml" ]] || err "$AIM_ROOT/docker-compose.quickstart.yml missing"
+docker info >/dev/null 2>&1 || err "Docker daemon not running. Start Docker Desktop and re-run."
+ok "AIM repo: $AIM_ROOT"
+ok "Docker daemon ready"
+
+step "Generate .env with shell-safe secrets"
+ENV_FILE="$AIM_ROOT/.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  cat > "$ENV_FILE" <<EOF
+POSTGRES_PASSWORD=$(openssl rand -hex 16)
+REDIS_PASSWORD=$(openssl rand -hex 16)
+JWT_SECRET=$(openssl rand -hex 32)
+KEYVAULT_MASTER_KEY=$(openssl rand -base64 32)
+EOF
+  ok "wrote $ENV_FILE"
+else
+  ok "$ENV_FILE exists (reusing)"
+fi
+
+step "Apply postgres port override (if host's 5432 is busy)"
+OVERRIDE_FILE="$AIM_ROOT/docker-compose.override.yml"
+if [[ ! -f "$OVERRIDE_FILE" ]]; then
+  cat > "$OVERRIDE_FILE" <<'EOF'
+# Local override: remap aim-postgres to host port 5433 so it coexists with
+# a local postgres on 5432. Container-internal port stays 5432; backend talks
+# to postgres via the internal docker network and is unaffected.
+services:
+  postgres:
+    ports:
+      - "127.0.0.1:5433:5432"
+EOF
+  ok "wrote $OVERRIDE_FILE"
+else
+  ok "$OVERRIDE_FILE exists (reusing)"
+fi
+
+step "Bring up the stack (postgres + redis + backend + frontend)"
+( cd "$AIM_ROOT" && docker compose -f docker-compose.quickstart.yml -f docker-compose.override.yml --env-file .env up -d >/dev/null )
+ok "compose up issued"
+
+step "Wait for backend health (up to 60s)"
+for i in $(seq 1 12); do
+  if curl -fsS -m 2 "$BACKEND_URL/health" >/dev/null 2>&1; then
+    ok "backend healthy (took ${i}5s)"
+    break
+  fi
+  sleep 5
+done
+curl -fsS -m 2 "$BACKEND_URL/health" >/dev/null 2>&1 || err "backend never became healthy (check: docker logs aim-backend)"
+
+step "Seed admin user (if not already present)"
+EXISTING=$(docker exec aim-postgres psql -U postgres -d identity -tA -c "SELECT count(*) FROM users WHERE email = '$ADMIN_EMAIL';" 2>/dev/null || echo 0)
+if [[ "$EXISTING" = "0" ]]; then
+  cat > /tmp/dvaa-seed-admin.sql <<SQL
+INSERT INTO users (organization_id, email, name, role, provider, provider_id, password_hash, status, email_verified, force_password_change)
+SELECT id, '$ADMIN_EMAIL', 'DVAA Local Admin', 'admin', 'local', '$ADMIN_EMAIL', '$ADMIN_PW_HASH', 'active', TRUE, FALSE
+FROM organizations WHERE domain = 'admin.opena2a.org';
+SQL
+  docker cp /tmp/dvaa-seed-admin.sql aim-postgres:/tmp/dvaa-seed-admin.sql >/dev/null
+  docker exec aim-postgres psql -U postgres -d identity -f /tmp/dvaa-seed-admin.sql >/dev/null 2>&1
+  rm -f /tmp/dvaa-seed-admin.sql
+  ok "admin user seeded ($ADMIN_EMAIL / $ADMIN_PASSWORD)"
+else
+  ok "admin user already present"
+fi
+
+step "Log in to capture JWT"
+LOGIN_RESP=$(curl -fsS -m 5 -X POST -H 'Content-Type: application/json' \
+  -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}" \
+  "$BACKEND_URL/api/v1/public/login")
+JWT=$(echo "$LOGIN_RESP" | node -e "let d=''; process.stdin.on('data',c=>d+=c).on('end',()=>{const j=JSON.parse(d); process.stdout.write(j.accessToken||'')})")
+[[ -n "$JWT" ]] || err "JWT not returned from login (login resp: $LOGIN_RESP)"
+ok "JWT captured (${#JWT} chars)"
+
+step "Generate DVAA's Ed25519 identity for ragbot-aim (if missing)"
+ID_FILE="$DVAA_ROOT/.dvaa-aim/ragbot-aim/identity.json"
+PUBKEY=$(cd "$DVAA_ROOT" && node -e "
+import('@opena2a/aim-core').then(async (m) => {
+  const path = await import('path');
+  const fs = await import('fs');
+  const dataDir = path.join('$DVAA_ROOT', '.dvaa-aim', 'ragbot-aim');
+  fs.mkdirSync(dataDir, { recursive: true });
+  const core = new m.AIMCore({ agentName: 'ragbot-aim', dataDir });
+  const id = core.getOrCreateIdentity();
+  process.stdout.write(id.publicKey);
+});
+")
+[[ -n "$PUBKEY" ]] || err "Ed25519 keygen failed"
+ok "public key: $PUBKEY"
+ok "identity file: $ID_FILE"
+
+step "Check if dvaa-ragbot-aim already registered"
+EXISTING_AGENT=$(curl -fsS -m 5 -H "Authorization: Bearer $JWT" "$BACKEND_URL/api/v1/agents" | node -e "
+let d=''; process.stdin.on('data',c=>d+=c).on('end',()=>{
+  const j=JSON.parse(d);
+  const a=(j.agents||[]).find(a => a.name === 'dvaa-ragbot-aim');
+  if (a) process.stdout.write(a.id);
+});
+")
+
+if [[ -n "$EXISTING_AGENT" ]]; then
+  CLOUD_AGENT_ID="$EXISTING_AGENT"
+  ok "agent already registered: $CLOUD_AGENT_ID"
+else
+  step "Register dvaa-ragbot-aim with the public key"
+  CREATE_RESP=$(curl -fsS -m 10 -X POST -H "Authorization: Bearer $JWT" -H 'Content-Type: application/json' \
+    -d "{
+      \"name\": \"dvaa-ragbot-aim\",
+      \"displayName\": \"DVAA RAGBot-AIM\",
+      \"description\": \"DVAA 15th agent: same RAG code as RAGBot, AIM capability enforcement at the tool boundary\",
+      \"agentType\": \"custom\",
+      \"version\": \"0.8.3\",
+      \"publicKey\": \"$PUBKEY\",
+      \"capabilities\": [\"rag:read\", \"chat:respond\"]
+    }" \
+    "$BACKEND_URL/api/v1/agents")
+  CLOUD_AGENT_ID=$(echo "$CREATE_RESP" | node -e "let d=''; process.stdin.on('data',c=>d+=c).on('end',()=>{const j=JSON.parse(d); process.stdout.write(j.id||'')})")
+  [[ -n "$CLOUD_AGENT_ID" ]] || err "registration failed (resp: $CREATE_RESP)"
+  ok "registered agent id: $CLOUD_AGENT_ID"
+fi
+
+step "Done — next steps"
+cat <<EOF
+
+  Dashboard:    $DASHBOARD_URL
+  Login:        $ADMIN_EMAIL  /  $ADMIN_PASSWORD
+
+  Start DVAA with cloud reporting enabled (in another terminal):
+
+    export AIM_SERVER_URL=$BACKEND_URL
+    export AIM_API_KEY=not_required_for_local_verifications
+    export DVAA_AIM_CLOUD_AGENT_ID=$CLOUD_AGENT_ID
+    cd $DVAA_ROOT
+    node src/index.js --api
+
+  Then run the demo (in a third terminal):
+
+    cd $DVAA_ROOT
+    node src/index.js demo aim-ab
+
+  Refresh the dashboard's Verification Events page to see the events land.
+
+  To tear down: docker compose -f $AIM_ROOT/docker-compose.quickstart.yml -f $AIM_ROOT/docker-compose.override.yml --env-file $AIM_ROOT/.env down
+
+EOF

--- a/src/aim-cloud-reporter.js
+++ b/src/aim-cloud-reporter.js
@@ -1,0 +1,192 @@
+/**
+ * Cloud-mode reporter for the AIM dashboard at api.aim.opena2a.org.
+ *
+ * Local-first enforcement via aim-core remains authoritative. This module
+ * is purely additive: when the cloud env vars are set, every enforcement
+ * decision is mirrored as a signed verification request to the cloud so
+ * the dashboard can show the registered agent + audit events + trust score.
+ *
+ * Activation gates (ALL three required to enable cloud reporting):
+ *   - process.env.AIM_SERVER_URL (e.g. https://api.aim.opena2a.org)
+ *   - process.env.AIM_API_KEY (any aim_live_/aim_test_ key, used as X-API-Key)
+ *   - process.env.DVAA_AIM_CLOUD_AGENT_ID (UUID returned by the dashboard
+ *     when the agent was registered with this DVAA install's public key)
+ *
+ * Without all three, the reporter no-ops. The local audit log + capability
+ * decision still happens regardless.
+ *
+ * Contract matches the Python SDK at aim_sdk/client.py:504-620
+ * (verify_capability). The signature payload uses 'action_type' (Python
+ * legacy field name) while the request body uses 'capability'. JSON
+ * serialization MUST match Python's json.dumps(sort_keys=True,
+ * separators=(', ', ': ')) — that's the canonical bytes the server
+ * re-serializes and verifies.
+ */
+
+import https from 'https';
+import http from 'http';
+import { URL } from 'url';
+
+const VERIFICATIONS_PATH = '/api/v1/sdk-api/verifications';
+
+export function cloudReporterEnabled() {
+  return Boolean(
+    process.env.AIM_SERVER_URL &&
+    process.env.AIM_API_KEY &&
+    process.env.DVAA_AIM_CLOUD_AGENT_ID,
+  );
+}
+
+/**
+ * Python-compatible JSON serialization.
+ *
+ * Python: json.dumps(obj, sort_keys=True, separators=(', ', ': '))
+ *   - keys sorted at every nesting level
+ *   - comma followed by space between items
+ *   - colon followed by space between key and value
+ *
+ * Node JSON.stringify has neither sorted keys nor configurable separators,
+ * so we walk the object ourselves.
+ */
+export function pythonJsonStringify(value) {
+  if (value === null) return 'null';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('non-finite number not JSON-serializable');
+    return String(value);
+  }
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return '[' + value.map(pythonJsonStringify).join(', ') + ']';
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return '{' + keys.map(k => JSON.stringify(k) + ': ' + pythonJsonStringify(value[k])).join(', ') + '}';
+  }
+  throw new Error('unsupported type for JSON: ' + typeof value);
+}
+
+/**
+ * Sign + POST one verification request to the cloud.
+ *
+ * `signFn` is a function (Buffer-or-string -> Buffer-or-Uint8Array) — pass
+ * `core.sign.bind(core)` where `core` is the same AIMCore instance the
+ * enforcer is already using. This guarantees the signature comes from the
+ * SAME private key the dashboard agent was registered with.
+ *
+ * Returns { ok: true, verificationId, verified, status } on success,
+ * { ok: false, error, status, body? } on failure. Never throws — the
+ * cloud is best-effort; local enforcement already happened.
+ */
+export async function postVerification({
+  serverUrl,
+  cloudAgentId,
+  publicKey,
+  signFn,
+  apiKey,
+  action,
+  resource,
+  context,
+  result,
+  timeoutMs = 5000,
+}) {
+  if (!serverUrl || !cloudAgentId || !publicKey || typeof signFn !== 'function') {
+    return { ok: false, error: 'missing_config' };
+  }
+
+  const timestamp = new Date().toISOString();
+
+  // Signature payload — MUST use 'action_type' (server expects legacy field).
+  // Keys are sorted by pythonJsonStringify.
+  const signaturePayload = {
+    action_type: action,
+    agent_id: cloudAgentId,
+    context: context || {},
+    resource: resource || null,
+    timestamp,
+  };
+  const signatureMessage = pythonJsonStringify(signaturePayload);
+
+  let signatureB64;
+  try {
+    const sigBytes = signFn(Buffer.from(signatureMessage, 'utf-8'));
+    signatureB64 = Buffer.from(sigBytes).toString('base64');
+  } catch (e) {
+    return { ok: false, error: 'sign_failed', detail: e.message };
+  }
+
+  // Request body — uses 'capability' (live field name) + signature + publicKey.
+  const requestBody = JSON.stringify({
+    agentId: cloudAgentId,
+    capability: action,
+    resource: resource || null,
+    context: context || {},
+    timestamp,
+    signature: signatureB64,
+    publicKey,
+    // Local enforcement result for the dashboard's records — even though
+    // the cloud will independently decide based on the capability rules
+    // associated with the registered agent.
+    enforcementResult: result || 'unknown',
+  });
+
+  return await postBody({ serverUrl, path: VERIFICATIONS_PATH, body: requestBody, apiKey, timeoutMs });
+}
+
+function postBody({ serverUrl, path, body, apiKey, timeoutMs }) {
+  let url;
+  try { url = new URL(path, serverUrl); } catch (e) {
+    return Promise.resolve({ ok: false, error: 'invalid_server_url', detail: e.message });
+  }
+  const driver = url.protocol === 'https:' ? https : http;
+  const headers = {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+    'User-Agent': 'dvaa-aim-enforcer/0.8.3',
+  };
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey;
+  }
+  return new Promise((resolve) => {
+    const req = driver.request(
+      {
+        hostname: url.hostname,
+        port: url.port || (url.protocol === 'https:' ? 443 : 80),
+        path: url.pathname + url.search,
+        method: 'POST',
+        headers,
+        timeout: timeoutMs,
+      },
+      (res) => {
+        let buf = '';
+        res.on('data', (chunk) => { buf += chunk.toString('utf-8'); });
+        res.on('end', () => {
+          let parsed = null;
+          try { parsed = JSON.parse(buf); } catch { parsed = null; }
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve({
+              ok: true,
+              status: res.statusCode,
+              verificationId: parsed?.id || parsed?.verification_id || parsed?.verificationId || null,
+              verified: parsed?.verified ?? (parsed?.status === 'auto-approved' || parsed?.status === 'approved'),
+              cloudStatus: parsed?.status ?? null,
+              cloudTrustScore: parsed?.trustScore ?? null,
+              body: parsed,
+            });
+          } else {
+            resolve({
+              ok: false,
+              error: 'http_' + res.statusCode,
+              status: res.statusCode,
+              body: parsed || buf.slice(0, 400),
+            });
+          }
+        });
+      },
+    );
+    req.on('timeout', () => { req.destroy(); resolve({ ok: false, error: 'timeout' }); });
+    req.on('error', (e) => resolve({ ok: false, error: e.code || 'request_error', detail: e.message }));
+    req.write(body);
+    req.end();
+  });
+}

--- a/src/aim-enforcer.js
+++ b/src/aim-enforcer.js
@@ -16,6 +16,7 @@
 import path from 'path';
 import fs from 'fs';
 import { AIMCore } from '@opena2a/aim-core';
+import { cloudReporterEnabled, postVerification } from './aim-cloud-reporter.js';
 
 const ENFORCEMENT_OFF = () => String(process.env.AIM_ENFORCEMENT || '').toLowerCase() === 'off';
 
@@ -84,6 +85,26 @@ export async function maybeEnforce(agent, { action, resource, context }) {
     // calculateTrust shouldn't throw on a freshly initialized core, but
     // never let the enforcer be the reason a request fails.
     trustScore = null;
+  }
+
+  // Cloud mirror (best-effort, never blocks the local decision). Fire-and-
+  // forget; the local enforcement decision has already been made and logged.
+  if (cloudReporterEnabled()) {
+    void postVerification({
+      serverUrl: process.env.AIM_SERVER_URL,
+      cloudAgentId: process.env.DVAA_AIM_CLOUD_AGENT_ID,
+      publicKey: core.getIdentity().publicKey,
+      signFn: (data) => core.sign(data),
+      apiKey: process.env.AIM_API_KEY,
+      action,
+      resource,
+      context,
+      result: allowed ? 'allowed' : 'denied',
+    }).then((res) => {
+      if (!res.ok && process.env.DVAA_AIM_CLOUD_DEBUG) {
+        process.stderr.write(`[aim-cloud] verification report failed: ${res.error}${res.status ? ' (HTTP ' + res.status + ')' : ''}\n`);
+      }
+    });
   }
 
   if (!allowed) {


### PR DESCRIPTION
## Summary

Adds optional cloud-mode reporting on top of the local-first AIM enforcer from #42. When three env vars are set on the DVAA fleet (`AIM_SERVER_URL`, `AIM_API_KEY`, `DVAA_AIM_CLOUD_AGENT_ID`), every enforcement decision is mirrored as a signed verification request to an AIM server, where the agent appears in the dashboard with its registered identity, audit trail, and trust score.

This is the **conversion-funnel** half of the work: the CLI demo shows AIM blocks an action; the dashboard shows the registered agent + event history so a viewer can connect "DVAA proves AIM works" → "install AIM for my own agent."

**Local-first remains authoritative.** The cloud post is fire-and-forget on a separate code path. It never blocks the user-facing response. With no env vars set, behavior is byte-identical to #42 — `dvaa demo aim-ab` still PASS verdict, 75/75 existing tests still pass.

## What changed

| File | Change |
|---|---|
| `src/aim-cloud-reporter.js` | NEW — Ed25519-signed POST to `/api/v1/sdk-api/verifications` matching Python `aim-sdk@1.21.0` `verify_capability` wire format. Pythonn-compatible JSON serialization (`pythonJsonStringify`) for byte-exact signature reconstruction. |
| `src/aim-enforcer.js` | Calls `postVerification()` after the local enforcement decision when `cloudReporterEnabled()` returns true. Best-effort, never throws back to caller. |
| `docs/demo/setup-aim-local.sh` | NEW — one-shot script that brings up the 4-service AIM stack (`docker compose up` against the sibling `agent-identity-management` repo), seeds a local admin user, captures a JWT, registers `dvaa-ragbot-aim` with DVAA's locally-generated Ed25519 public key, prints the env vars to copy into `dvaa --api`. Idempotent. |
| `DEMO_BUILD.md` | New "Cloud mode" section with the contract details (endpoint, signature scheme, auth model) and runbook. Tear-down steps. |

## Wire-format / contract

| Aspect | Value |
|---|---|
| Endpoint | `POST /api/v1/sdk-api/verifications` |
| Auth | Ed25519 signature IN the body (`signature` + `publicKey` fields). NO bearer header. `X-API-Key` sent but ignored on this endpoint. |
| Sig payload | `{action_type, agent_id, context, resource, timestamp}` — sorted keys, Python's default JSON separators `(', ', ': ')` |
| Request body | `{agentId, capability, resource, context, timestamp, signature, publicKey, enforcementResult}` |
| Server response | 201 `{id, status: 'auto-approved', trustScore, riskLevel, enforcementMode}` |

## Test plan

- [x] `node --check` clean on both new/modified `.js` files; `bash -n` clean on the setup script
- [x] 75/75 existing tests pass
- [x] **Local-only regression**: with NO cloud env vars set, `dvaa demo aim-ab` still PASS verdict (default-path behavior preserved)
- [x] **Cloud-mode end-to-end**: ran setup-aim-local.sh on a fresh laptop, exported the printed env vars, ran `dvaa demo aim-ab` twice → 3 real verification_events rows persisted to local postgres with valid Ed25519 signatures the backend accepted
- [x] **Setup script idempotency**: second `./docs/demo/setup-aim-local.sh` correctly detects existing .env, existing override, existing admin user, existing agent → reuses all of them
- [x] **pythonJsonStringify byte-accuracy**: smoke-tested against known Python `json.dumps(sort_keys=True, separators=(', ', ': '))` output on nested objects + the actual signature payload shape
- [x] **Dashboard renders**: `http://localhost:3000` returns 200, redirects unauth to login, route `/agents` and `/verifications` exist (full UI exercise via Playwright deferred — browser was locked during this session; the user takes SVCC-deck screenshots on their machine)

## Notes for SVCC presenter

1. Run `./docs/demo/setup-aim-local.sh` once on the stage laptop. It prints the env vars; export them in the terminal that runs `dvaa --api`.
2. Live demo: terminal 1 `dvaa --api`, terminal 2 `dvaa demo aim-ab`, browser tab `http://localhost:3000` (login `admin@opena2a.org` / `AIM2025!Secure`). Refresh the Verification Events page after the demo finishes.
3. The admin password is the documented DVAA-CTF default. **Do not point this script at any AIM stack reachable from the public internet.**
4. To later flip from local to real cloud: change `AIM_SERVER_URL` and `DVAA_AIM_CLOUD_AGENT_ID` only. The signing code is identical.

## Honest scope reminder

This PR doesn't broaden AIM's enforcement surface — RAGBot-AIM still only blocks the one `http:post` action. Other in-band leak paths (response-text `dataExfiltration` regex) remain unenforced on the AIM agent in this build. Per the conversion-funnel framing in DEMO_BUILD.md, the demo should pitch the narrow verifiable claim ("AIM denied this specific outbound action because http:post is outside the agent's capability grant") rather than the broad "AIM secures the agent."