### PR TITLE
chore(release): 0.9.1 — drain 0.9.0 known-issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog — damn-vulnerable-ai-agent
 
+## 0.9.1
+
+### Fixed — UX papercuts from the 0.9.0 release-test
+
+Drains the three "Known issues will fix in 0.9.1" items from 0.9.0's CHANGELOG. Two of them lived in `@opena2a/cli-ui` and were fixed at root (cli-ui 0.5.1); one was local to `src/browse.js`.
+
+- **`dvaa telemetry --help`** now prints a proper usage block (actions, per-invocation override `OPENA2A_TELEMETRY=off`, debug knob `OPENA2A_TELEMETRY_DEBUG=print`). Previously fell into the cli-ui `Unknown action` default branch and printed `Unknown action '--help'. Try 'dvaa telemetry [on|off|status]'.`. Root-cause fix in `@opena2a/cli-ui@0.5.1` `runTelemetryCommand`; consumed here by bumping the pin.
+- **`dvaa telemetry status`** toggle hint now flips based on current state — suggests `off` + `OPENA2A_TELEMETRY=off` when telemetry is on, suggests `on` + `OPENA2A_TELEMETRY=on` when telemetry is off. Previously always suggested `off`, which was useless when telemetry was already off. Root-cause fix in `@opena2a/cli-ui@0.5.1` `renderStatus`.
+- **`dvaa browse --help`** now prints a browse-specific usage block (target arg, `--agents`, `--categories`, `--json`, `--publish`, `--verbose`) instead of falling back to the root `dvaa --help`. Root cause: `src/index.js`'s global `--help` check ran before the `browse` handler. Reordered so the `browse` subprocess spawn happens first, then `src/browse.js` checks `--help`/`-h` and prints its own usage. Subcommand-dispatched commands (`chat`, `demo`, `telemetry`, etc.) already had this property via `dispatch()`; only `browse` was special-cased.
+
+### Changed — dependencies
+
+- Bumped `@opena2a/cli-ui` pin from `0.4.0` to `0.5.1`. 0.5.0 (rich-context check block primitives, 2026-05-09) was a feature release we hadn't picked up yet; 0.5.1 (this release-test fixes) is what 0.9.1 actually needs. No DVAA code depends on 0.5.0's new exports.
+
+### Tests
+
+- `test/browse-help.test.js` (NEW): 3 subprocess tests asserting `--help` exits 0 + prints browse-specific text + does NOT leak root help (the exact bug class). Locks the fix in so a future index.js refactor can't reintroduce the regression.
+
+### Honest scope
+
+This release ships only the UX papercuts from 0.9.0's release-test. No new agents, no new commands, no AIM behavior change. RAGBot-AIM and ResearchBot-AIM enforcement contracts are unchanged.
+
 ## 0.9.0
 
 ### Added — AIM A/B demo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "damn-vulnerable-ai-agent",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "damn-vulnerable-ai-agent",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.74.0",
-        "@opena2a/aim-core": "^0.2.0",
-        "@opena2a/cli-ui": "0.4.0",
+        "@opena2a/aim-core": "0.2.0",
+        "@opena2a/cli-ui": "0.5.1",
         "@opena2a/telemetry": "0.1.2",
         "hackmyagent": "^0.11.0",
         "openai": "^6.21.0"
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@opena2a/cli-ui": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.4.0.tgz",
-      "integrity": "sha512-wro+mk1znr1PbEr9XvdI1jovP8qFpfuKoBYouf6XVkHTfLJ1z09Zpli6dEjB6bFz/HxLtZbJ9zg8aaurqFxTjQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@opena2a/cli-ui/-/cli-ui-0.5.1.tgz",
+      "integrity": "sha512-QfiZUEQS8HIHQKthZrXSGyO4OP3t2/AhR1/YDvglkbDstg6lG2GL5/O2UjH+8PlIBRhBzSvMpJt0OuCoVVuHoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "damn-vulnerable-ai-agent",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The AI agent you're supposed to break. 17 agents, 12 vulnerability categories, zero consequences.",
   "type": "module",
   "main": "src/index.js",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
     "@opena2a/aim-core": "0.2.0",
-    "@opena2a/cli-ui": "0.4.0",
+    "@opena2a/cli-ui": "0.5.1",
     "@opena2a/telemetry": "0.1.2",
     "hackmyagent": "^0.11.0",
     "openai": "^6.21.0"

--- a/src/browse.js
+++ b/src/browse.js
@@ -23,6 +23,41 @@
 import { getAllAgents } from './core/agents.js';
 
 const args = process.argv.slice(2);
+
+const USAGE = `dvaa browse [target] [options]
+
+Send DVAA agents to browse a target site and report which agents get
+pwned at which attack tiers. Default target: https://www.agentpwn.com.
+
+Arguments:
+  [target]                  HTTPS URL to send the agents to.
+                            Default: https://www.agentpwn.com
+
+Options:
+  --agents <ids>            Comma-separated agent ids to include
+                            (e.g. helperbot,legacybot). Default: all api agents.
+  --categories <cats>       Comma-separated attack categories to test
+                            (e.g. prompt-injection,data-exfiltration).
+                            Default: all categories in the payload set.
+  --json                    Machine-readable JSON output.
+  --publish                 Submit the results to the Registry.
+  --verbose, -v             Include per-payload detail.
+  --help, -h                Show this message.
+
+Examples:
+  dvaa browse
+  dvaa browse https://example.com
+  dvaa browse --agents helperbot,legacybot --json
+  dvaa browse --categories prompt-injection --verbose
+
+Requires: DVAA agents running in another terminal (dvaa --api).
+`;
+
+if (args.includes('--help') || args.includes('-h')) {
+  process.stdout.write(USAGE);
+  process.exit(0);
+}
+
 const TARGET = args.find(a => a.startsWith('http')) || 'https://www.agentpwn.com';
 const JSON_OUTPUT = args.includes('--json');
 const PUBLISH = args.includes('--publish');

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,24 @@ if (args.length > 0 && !args[0].startsWith('-')) {
   }
 }
 
+// Handle browse command — spawn with argv (not a shell template literal) so
+// arguments cannot be shell-interpreted. Template-literal exec was CVE-class
+// command injection: a user running `dvaa browse "; rm -rf ~"` would execute it.
+//
+// Runs BEFORE the global --help check below so `dvaa browse --help` reaches
+// browse.js's own help text instead of falling back to the root help.
+if (args[0] === 'browse') {
+  const { spawnSync } = await import('child_process');
+  const { dirname, join } = await import('path');
+  const { fileURLToPath } = await import('url');
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const result = spawnSync('node', [join(__dirname, 'browse.js'), ...args.slice(1)], {
+    stdio: 'inherit',
+    shell: false,
+  });
+  process.exit(result.status ?? 1);
+}
+
 // Handle --help / -h
 if (args.includes('--help') || args.includes('-h')) {
   const commands = listCommands();
@@ -92,21 +110,6 @@ Agents:
 Dashboard:  http://localhost:9000
 Docs:       https://github.com/opena2a-org/damn-vulnerable-ai-agent`);
   process.exit(0);
-}
-
-// Handle browse command — spawn with argv (not a shell template literal) so
-// arguments cannot be shell-interpreted. Template-literal exec was CVE-class
-// command injection: a user running `dvaa browse "; rm -rf ~"` would execute it.
-if (args[0] === 'browse') {
-  const { spawnSync } = await import('child_process');
-  const { dirname, join } = await import('path');
-  const { fileURLToPath } = await import('url');
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  const result = spawnSync('node', [join(__dirname, 'browse.js'), ...args.slice(1)], {
-    stdio: 'inherit',
-    shell: false,
-  });
-  process.exit(result.status ?? 1);
 }
 
 // Handle --version — uses the shared versionLine helper so the telemetry

--- a/test/browse-help.test.js
+++ b/test/browse-help.test.js
@@ -1,0 +1,70 @@
+/**
+ * Smoke test for `dvaa browse --help`.
+ *
+ * 0.9.0's release-test caught that `dvaa browse --help` fell back to
+ * `dvaa --help` (root help) because src/browse.js had no --help case.
+ * This test locks in the browse-specific help so the regression can't
+ * silently come back.
+ */
+
+import { strict as assert } from 'assert';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), '..');
+const CLI = path.join(REPO_ROOT, 'src', 'index.js');
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  PASS  ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  FAIL  ${name}: ${err.message}`);
+  }
+}
+
+function runBrowse(args) {
+  return spawnSync('node', [CLI, 'browse', ...args], {
+    encoding: 'utf-8', shell: false, timeout: 8_000,
+  });
+}
+
+console.log('dvaa browse --help tests\n=========================\n');
+
+test('--help exits 0 and prints browse-specific usage', () => {
+  const r = runBrowse(['--help']);
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}\nstderr: ${r.stderr}`);
+  const out = r.stdout + r.stderr;
+  assert.ok(out.includes('dvaa browse'), 'header missing');
+  assert.ok(out.includes('target'), 'target arg description missing');
+  assert.ok(out.includes('--agents'), 'expected --agents flag in help');
+  assert.ok(out.includes('--categories'), 'expected --categories flag in help');
+  assert.ok(out.includes('--json'), 'expected --json flag in help');
+  assert.ok(out.includes('--publish'), 'expected --publish flag in help');
+  assert.ok(out.includes('agentpwn.com'), 'expected default target hint');
+});
+
+test('-h alias works the same as --help', () => {
+  const r = runBrowse(['-h']);
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}\nstderr: ${r.stderr}`);
+  const out = r.stdout + r.stderr;
+  assert.ok(out.includes('dvaa browse'), 'header missing on -h');
+});
+
+test('--help does NOT fall back to root help (regression from 0.9.0 release-test)', () => {
+  const r = runBrowse(['--help']);
+  const out = r.stdout + r.stderr;
+  // Root help includes phrases unique to it (e.g. "Server options" + "Dashboard:  http://localhost:9000").
+  // Browse help must not contain those — that's the bug class.
+  assert.ok(!out.includes('Server options'), 'root help leaked through — browse --help is falling back');
+  assert.ok(!out.includes('Dashboard:  http://localhost:9000'), 'root help leaked through');
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Drains the three UX papercuts I documented as "Known issues will fix in 0.9.1" in 0.9.0's CHANGELOG. Two were in \`@opena2a/cli-ui\`'s \`runTelemetryCommand\` (fixed at root in cli-ui 0.5.1 via opena2a#170); one was local to \`src/browse.js\`.

### What changed

| Bug | Where | Fix |
|---|---|---|
| \`dvaa telemetry --help\` prints "Unknown action '--help'" | cli-ui \`runTelemetryCommand\` (default branch) | cli-ui 0.5.1: explicit \`--help\` / \`-h\` cases; pin bump here |
| \`dvaa telemetry status\` toggle hint always says "off" | cli-ui \`renderStatus\` (hardcoded) | cli-ui 0.5.1: flip on \`status.enabled\`; pin bump here |
| \`dvaa browse --help\` falls back to root help | DVAA \`src/index.js\` ran global \`--help\` check before \`browse\` handler | reordered + added \`--help\` to \`src/browse.js\` |

### Live verification

\`\`\`
$ node src/index.js telemetry --help
dvaa telemetry [on|off|status]
Inspect or toggle the persisted anonymous-telemetry opt-out for dvaa.
Default action (no args) is 'status'.
Actions:
  on        Enable telemetry persistently for dvaa.
  off       Disable telemetry persistently for dvaa.
  status    Show current state, install_id, config file, and policy URL.
  --help    Show this message.
...

$ node src/index.js telemetry status     # state: on
  toggle: 'dvaa telemetry off'  or  OPENA2A_TELEMETRY=off

$ node src/index.js telemetry off && node src/index.js telemetry status     # state: off
  toggle: 'dvaa telemetry on'   or  OPENA2A_TELEMETRY=on    <-- fixed direction

$ node src/index.js browse --help
dvaa browse [target] [options]
Send DVAA agents to browse a target site...
...                                                          <-- browse-specific, not root help
\`\`\`

### Dependencies

Bumps \`@opena2a/cli-ui\` pin from \`0.4.0\` to \`0.5.1\`. 0.5.0 was a feature release (rich-context check block primitives) we hadn't picked up; 0.5.1 is what 0.9.1 actually needs. No DVAA code depends on 0.5.0 exports.

### Tests

- \`test/browse-help.test.js\` (NEW): 3 subprocess tests asserting \`browse --help\` exits 0, prints browse-specific text, and does NOT leak root help (locks in the regression so a future \`index.js\` refactor can't reintroduce it).
- All existing tests pass: 19 LLM-mode + 15 research-agent + 75 novel-agents + 6 cli-hma + playground + attack-log.

### Scope

No new agents, no new commands, no AIM behavior change. \`dvaa demo aim-ab\` unaffected. Tarball: 456 files (identical count to 0.9.0); cruft check clean.

## Test plan

- [x] All test files PASS
- [x] \`npm pack\` cruft check: no \`.dvaa-aim/\`, no marker files, no \`CLAUDE.md\`, no \`.github/\`
- [x] Live smoke: all 4 fixes (\`telemetry --help\`, toggle direction on, toggle direction off, \`browse --help\`) verified end-to-end on the bumped \`@opena2a/cli-ui@0.5.1\`