### PR TITLE
ci: opt release.yml into Node 24 for v4-line actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ permissions:
   contents: write
   id-token: write
 
+# Opt the v4-line JavaScript actions (checkout, setup-node, action-gh-release)
+# into Node 24 today. They run on Node 20 by default and emit a deprecation
+# warning on every release; the runner forces Node 24 on 2026-06-02. Setting
+# this env now silences the warning AND avoids surprise breakage in June.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

\`actions/checkout@v4\`, \`actions/setup-node@v4\`, and \`softprops/action-gh-release@v2\` are JavaScript actions that run on Node 20 by default. GitHub forces them to Node 24 on **2026-06-02**; until then they emit a deprecation warning on every release. The documented workaround is the env var \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\`.

Setting it at the workflow level silences the warning today AND avoids a small risk of regression on June 2nd when the runner flips the default.

No behavior change to the publish-step itself — \`setup-node\` already installs \`node-version: 24\` for the npm-publish; this is purely about the actions' own internal Node runtime.

## Test plan

- [x] YAML parses cleanly (\`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"\`)
- [x] Diff is +7 lines, all comment + env block
- [ ] On next release tag push, deprecation warning should be gone from the workflow run log

## Companion PRs

Same fix applied in opena2a / hackmyagent / ai-trust (the other three release.yml-publishing repos in the org). See those PRs for the parallel changes.