### PR TITLE
Remove remaining em dashes across the dashboard

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -898,7 +898,7 @@ body {
 }
 .md-body .md-link:hover { border-bottom-style: solid; }
 
-/* User-side chat bubbles get dark-on-teal text — adjust markdown colors */
+/* User-side chat bubbles get dark-on-teal text - adjust markdown colors */
 .chat-msg-user .md-body strong { color: inherit; }
 .chat-msg-user .md-body .md-inline-code { background: rgba(0, 0, 0, 0.15); color: #0a0e17; }
 .chat-msg-user .md-body .md-link { color: inherit; border-bottom-color: rgba(0, 0, 0, 0.3); }
@@ -972,7 +972,7 @@ body {
   border-color: rgba(6, 182, 212, 0.4);
 }
 
-/* Grid — max 3 columns at any viewport */
+/* Grid - max 3 columns at any viewport */
 .scenario-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -1,5 +1,5 @@
 /**
- * API client — fetch wrapper for all dashboard endpoints
+ * API client - fetch wrapper for all dashboard endpoints
  */
 
 const BASE = '';

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,5 +1,5 @@
 /**
- * Main app — router, polling, global state
+ * Main app - router, polling, global state
  */
 
 import { fetchHealth, fetchStats, fetchAgents, fetchChallenges, fetchAttackLog, fetchScenarios } from './api.js';
@@ -93,7 +93,7 @@ function route() {
 }
 
 // Views that own their own interactive state (textarea content, dropdown selection,
-// in-flight chat). Auto-poll must not re-render these — it would clobber user input.
+// in-flight chat). Auto-poll must not re-render these - it would clobber user input.
 // They re-render only on explicit navigation (hashchange).
 const INTERACTIVE_VIEWS = new Set(['attack-lab', 'settings', 'scenarios']);
 

--- a/public/js/components.js
+++ b/public/js/components.js
@@ -95,7 +95,7 @@ export function codeBlock(text) {
 }
 
 /**
- * Challenge completion icon — checkmark or dash
+ * Challenge completion icon - checkmark or dash
  */
 export function challengeStatusIcon(completed) {
   if (completed && completed.completedAt) {

--- a/public/js/markdown.js
+++ b/public/js/markdown.js
@@ -3,7 +3,7 @@
  *
  * Built for LLM-generated content (tutor panels, agent chat, AI
  * recommendations). Returns an array of DOM nodes you can append. Does NOT
- * touch innerHTML — every piece of text goes through createTextNode via the
+ * touch innerHTML - every piece of text goes through createTextNode via the
  * el() helper, so inline HTML / script tags in LLM output render as literal
  * text rather than executing.
  *
@@ -19,7 +19,7 @@
  *   [text](url)       external link
  *
  * NOT supported (yet): tables, blockquotes, nested lists, images, footnotes.
- * If the LLM emits these, they render as literal text — acceptable until
+ * If the LLM emits these, they render as literal text - acceptable until
  * someone ships a use case that needs them.
  */
 
@@ -136,7 +136,7 @@ function renderTextBlock(text) {
 
 /**
  * Inline renderer. Text with **bold**, *italic*, `code`, [text](url).
- * Returns an array of text nodes and elements — safe for appendChild via el().
+ * Returns an array of text nodes and elements - safe for appendChild via el().
  * All text hits createTextNode via the el() machinery, so no HTML injection.
  */
 function renderInline(text) {

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -1,5 +1,5 @@
 /**
- * Utility functions — formatters, color mappings, helpers
+ * Utility functions - formatters, color mappings, helpers
  */
 
 export const SECURITY_COLORS = {
@@ -113,7 +113,7 @@ export function el(tag, attrs = {}, ...children) {
     else if (key === 'style' && typeof val === 'object') Object.assign(elem.style, val);
     else if (key.startsWith('on')) elem.addEventListener(key.slice(2).toLowerCase(), val);
     else if (key === 'textContent') elem.textContent = val;
-    else if (key === 'innerHTML') { /* skip — use textContent for safety */ }
+    else if (key === 'innerHTML') { /* skip - use textContent for safety */ }
     else if (BOOLEAN_ATTRS.has(key)) {
       if (val) elem.setAttribute(key, '');
       // falsy → don't set the attribute at all

--- a/public/js/views/attack-lab.js
+++ b/public/js/views/attack-lab.js
@@ -1,5 +1,5 @@
 /**
- * Attack Lab — Interactive agent hacking with AI tutor guidance
+ * Attack Lab - Interactive agent hacking with AI tutor guidance
  */
 
 import { el } from '../utils.js';

--- a/public/js/views/scenarios.js
+++ b/public/js/views/scenarios.js
@@ -1,5 +1,5 @@
 /**
- * Scenarios view — Scenarios v2
+ * Scenarios view: Scenarios v2
  *
  * Dashboard-initiated HMA scans. Each card owns its own scan/fix state, and
  * the view is registered as an interactive view (see app.js) so the 2s data
@@ -199,7 +199,7 @@ function scenarioCard(scenario, state) {
   card.appendChild(meta);
 
   // Action row. Scenarios without expected-checks.json can't be verified, so
-  // the scan button would just error — show Details only in that case.
+  // the scan button would just error: show Details only in that case.
   const hasExpected = scenario.expectedChecks && scenario.expectedChecks.length > 0;
   const actions = el('div', { className: 'scenario-actions' });
   const scanBtn = hasExpected ? el('button', { className: 'btn btn-primary btn-sm' }, 'Scan scenario') : null;
@@ -278,7 +278,7 @@ function renderPanel(scenario, { result, error, fix }, ctx) {
 
   const panel = el('div', { className: 'scenario-result' });
 
-  // Remediation celebration banner — user just ran --fix and everything that
+  // Remediation celebration banner: user just ran --fix and everything that
   // was broken is now passing. Explicit, green, separate from the scan line.
   const resolvedCount = result.expectedDetail.filter(d => d.status === 'fixed').length;
   if (fix && result.fired.length === 0 && resolvedCount > 0) {
@@ -369,7 +369,7 @@ function renderFindingRow(d) {
     body.appendChild(el('div', { className: 'scenario-finding-guidance' },
       'Was firing before the fix, now passes.'));
   } else {
-    // Missing. Surface whatever we can — HMA registry metadata (description +
+    // Missing. Surface whatever we can: HMA registry metadata (description +
     // severity) plus the family-based diagnostic hint.
     if (d.severity || d.category) {
       const meta = el('div', { className: 'scenario-finding-file' });
@@ -384,7 +384,7 @@ function renderFindingRow(d) {
       d.diagnostic || 'This check was expected but did not fire.'));
     if (!d.inRegistry) {
       body.appendChild(el('div', { className: 'scenario-finding-guidance scenario-finding-diag' },
-        `${d.checkId} isn't in this HMA version's check-metadata output — the check may have been renamed or removed upstream.`));
+        `${d.checkId} isn't in this HMA version's check-metadata output: the check may have been renamed or removed upstream.`));
     }
   }
   row.appendChild(body);
@@ -559,7 +559,7 @@ function formatBytes(n) {
 
 /**
  * Force a re-render by manually re-running the view fn. We do this because
- * Scenarios is in INTERACTIVE_VIEWS — the 2s data poll skips it.
+ * Scenarios is in INTERACTIVE_VIEWS: the 2s data poll skips it.
  */
 function rerender(state) {
   const app = document.getElementById('app');

--- a/public/js/views/settings.js
+++ b/public/js/views/settings.js
@@ -1,5 +1,5 @@
 /**
- * Settings view — LLM API key configuration
+ * Settings view - LLM API key configuration
  */
 
 import { el } from '../utils.js';


### PR DESCRIPTION
Completes the em-dash cleanup. Sweeps the rest of the dashboard source: the one rendered string (Scenarios missing-check message) now uses a colon; remaining occurrences are code comments and CSS comments, switched to colon or hyphen. No em dashes remain anywhere under `public/`. No logic changed; full suite 28/28.