### PR TITLE
Simplify docker run port mapping to a single 7001-7021 range

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 An intentionally vulnerable AI agent platform for security training, red-teaming, and validating security tools. 19 agents, 12 vulnerability categories, 3 protocols. The [DVWA](https://dvwa.co.uk/) of AI agents.
 
 ```bash
-docker run -p 9000:9000 -p 7001-7008:7001-7008 -p 7010-7018:7010-7018 -p 7020-7021:7020-7021 opena2a/dvaa:0.9.1
+docker run -p 9000:9000 -p 7001-7021:7001-7021 opena2a/dvaa:0.9.1
 open http://localhost:9000
 ```
 
@@ -346,7 +346,7 @@ VERBOSE=true            # Detailed logging
 # Remap host ports 7001-7021 → 7501-7521. Container-internal ports stay unchanged.
 docker run -d -e HOST_PORT_OFFSET=500 \
   -p 9000:9000 \
-  -p 7501-7508:7001-7008 -p 7510-7516:7010-7016 -p 7520-7521:7020-7021 \
+  -p 7501-7521:7001-7021 \
   opena2a/dvaa:0.9.1
 ```
 


### PR DESCRIPTION
Collapses the four `-p` flags in the quickstart into two by mapping the contiguous `7001-7021` range (the unused 7009/7019 map harmlessly):

```
docker run -p 9000:9000 -p 7001-7021:7001-7021 opena2a/dvaa:0.9.1
```

Verified against the local image: dashboard up, all 19 agents reachable across the range (7001-7021 incl. FlightBot on 7017/7018). Also fixes the HOST_PORT_OFFSET troubleshooting example, which still stopped at 7016 and missed the FlightBot ports.