### PR TITLE
Proxy Attack Lab chat through the dashboard (enables one-port quickstart)

### DIFF
--- a/public/js/views/attack-lab.js
+++ b/public/js/views/attack-lab.js
@@ -17,7 +17,10 @@ let killChainProgress = [];
  * Send a message to the selected agent
  */
 async function sendMessage(agentId, port, message) {
-  const resp = await fetch(`http://localhost:${port}/v1/chat/completions`, {
+  // Route through the dashboard so the Attack Lab works with only :9000
+  // published. The server resolves the agent by id and forwards to its
+  // in-container port; no need to map every agent port to the host.
+  const resp = await fetch(`/api/agents/${encodeURIComponent(agentId)}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -481,6 +481,39 @@ export function createDashboardServer({ stats, attackLog, challengeState, agents
       return;
     }
 
+    // Proxy a chat message to an agent through the dashboard port. This lets the
+    // Attack Lab drive agents with only :9000 published, so the getting-started
+    // command does not have to map every agent port. Scoped to known agent ids
+    // (resolved from the registry) so the dashboard is not a general open proxy;
+    // agents listen on the container loopback at their internal port.
+    if (req.method === 'POST' && pathname.startsWith('/api/agents/') && pathname.endsWith('/chat')) {
+      const agentId = pathname.split('/')[3]; // /api/agents/:id/chat
+      const agent = agents.find(a => a.id === agentId);
+      if (!agent) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Agent not found' }));
+        return;
+      }
+      try {
+        const body = await parseBody(req);
+        const messages = Array.isArray(body.messages)
+          ? body.messages
+          : [{ role: 'user', content: body.message || '' }];
+        const upstream = await fetch(`http://127.0.0.1:${agent.port}/v1/chat/completions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: 'dvaa', messages }),
+        });
+        const data = await upstream.json();
+        res.writeHead(upstream.status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(data));
+      } catch (err) {
+        res.writeHead(502, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Agent request failed', detail: err.message }));
+      }
+      return;
+    }
+
     // Tracks list
     if (req.method === 'GET' && pathname === '/api/tracks') {
       res.writeHead(200, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Why
The Attack Lab was the only dashboard feature that called agent ports directly from the browser, so a container publishing only `:9000` had a broken Attack Lab. Everything else already routed through the dashboard API.

## What
- New scoped route `POST /api/agents/:id/chat` resolves the agent by id from the registry and forwards to its in-container port.
- Attack Lab now calls that route instead of `http://localhost:<port>`.
- Scoped to known agent ids (404 otherwise), targets container loopback — not a general open proxy.

## Result
The whole dashboard now works with only `:9000` published, which unblocks a one-port getting-started command:
```
docker run -p 9000:9000 opena2a/dvaa
```
Direct agent attacks (curl, HackMyAgent) still need the agent ports published — separate documented step.

## Verified
End-to-end in the browser on a 9000-only container: selected LegacyBot, sent a prompt injection, agent leaked credentials through the proxy. Full suite 28/28. SecureBot still blocks through the proxy (no SSRF; port comes from our registry, not user input).

## Follow-up (not in this PR)
The README quickstart flip + the published image both need a new image release (`v0.9.2`), since `opena2a/dvaa:0.9.1` predates this proxy.