### PR TITLE
Lead with the all-ports docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 An intentionally vulnerable AI agent platform for security training, red-teaming, and validating security tools. 19 agents, 12 vulnerability categories, 3 protocols. The [DVWA](https://dvwa.co.uk/) of AI agents.
 
 ```bash
-docker run -p 9000:9000 opena2a/dvaa:0.9.2
+docker run -p 9000:9000 -p 7001-7021:7001-7021 opena2a/dvaa:0.9.2
 open http://localhost:9000
 ```
 
-> The dashboard on `:9000` drives the full fleet, including the Attack Lab. To attack agents directly from your host with `curl` or HackMyAgent, also publish the agent ports: add `-p 7001-7021:7001-7021`.
+> This maps every port: the dashboard on `:9000` and all 19 agents on `7001-7021`, so the dashboard, `curl`, and HackMyAgent all work. Docker does not publish ports without `-p`, so a bare `docker run` reaches nothing. (Only want the dashboard? `-p 9000:9000` alone is enough; it drives the whole fleet through `:9000`.)
 
 > **v0.8.0 breaking change:** agent ports moved from `3000`-base to `7000`-base to avoid the common `3000` collision with Next.js/React dev servers. Dashboard stays on `9000`. See [Upgrading from v0.7.x](#upgrading-from-v07x).
 


### PR DESCRIPTION
Reverts the one-port command as the hero. A bare `docker run` publishes nothing (Docker requires `-p`), and leading with `-p 9000:9000` only left direct `curl`/HackMyAgent broken without a documented second step, which read as confusing.

New hero maps every port in one command so the dashboard, curl, and HMA all work at once:
```
docker run -p 9000:9000 -p 7001-7021:7001-7021 opena2a/dvaa:0.9.2
```
The dashboard-only `-p 9000:9000` (which drives the whole fleet through the proxy) stays as a parenthetical, not a required tier.