### PR TITLE
Refresh the Docker Hub overview (DOCKER_README)

### DIFF
--- a/.github/workflows/docker-hub-description.yml
+++ b/.github/workflows/docker-hub-description.yml
@@ -25,4 +25,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PAT }}
           repository: opena2a/dvaa
           readme-filepath: ./DOCKER_README.md
-          short-description: "Damn Vulnerable AI Agent — intentionally vulnerable AI agents for security testing and red-teaming"
+          short-description: "Damn Vulnerable AI Agent: intentionally vulnerable AI agents for security testing and red-teaming"

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -2,12 +2,12 @@
 
 **The AI agent you're supposed to break.**
 
-17 agents. 8 attack classes. Zero consequences. DVAA is an intentionally vulnerable AI agent platform for learning, red-teaming, and validating security tools. Think [DVWA](https://dvwa.co.uk/) / [OWASP WebGoat](https://owasp.org/www-project-webgoat/), but for AI agents.
+19 agents. 12 attack classes. Zero consequences. DVAA is an intentionally vulnerable AI agent platform for learning, red-teaming, and validating security tools. Think [DVWA](https://dvwa.co.uk/) / [OWASP WebGoat](https://owasp.org/www-project-webgoat/), but for AI agents.
 
-- **Learn** — Understand AI agent vulnerabilities hands-on with CTF-style challenges (5,900 total points)
-- **Attack** — Practice prompt injection, jailbreaking, data exfiltration, and more
-- **Defend** — Develop and test security controls against real attack patterns
-- **Validate** — Use as a target for security scanners like [HackMyAgent](https://github.com/opena2a-org/hackmyagent)
+- **Learn:** understand AI agent vulnerabilities hands-on with CTF-style challenges (5,900 total points)
+- **Attack:** practice prompt injection, jailbreaking, data exfiltration, and more
+- **Defend:** develop and test security controls against real attack patterns
+- **Validate:** use as a target for security scanners like [HackMyAgent](https://github.com/opena2a-org/hackmyagent)
 
 > **Warning:** DVAA is intentionally insecure. DO NOT deploy in production or expose to the internet.
 
@@ -16,15 +16,15 @@
 ```bash
 docker run -d --name dvaa \
   -p 9000:9000 \
-  -p 7001-7008:7001-7008 \
-  -p 7010-7016:7010-7016 \
-  -p 7020-7021:7020-7021 \
-  opena2a/dvaa:0.9.1
+  -p 7001-7021:7001-7021 \
+  opena2a/dvaa:0.9.2
 ```
 
 Open the dashboard at [http://localhost:9000](http://localhost:9000).
 
-> **v0.8.0 breaking change:** agent ports moved `3000` → `7000` to avoid the common collision with Next.js/React dev servers. Dashboard stays on `9000`. See [Upgrading from v0.7.x](#upgrading-from-v07x).
+This maps every port: the dashboard on `9000` and all 19 agents on `7001-7021`, so the dashboard, `curl`, and HackMyAgent all work. Docker does not publish ports without `-p`, so a bare `docker run` reaches nothing. (Only want the dashboard? `-p 9000:9000` alone is enough; it drives the whole fleet through `:9000`.)
+
+> **v0.8.0 breaking change:** agent ports moved `3000` to `7000` to avoid the common collision with Next.js/React dev servers. Dashboard stays on `9000`. See [Upgrading from v0.7.x](#upgrading-from-v07x).
 
 ### Docker Compose
 
@@ -38,34 +38,34 @@ docker compose up
 
 The Prompt Playground and Attack Lab support testing with real LLMs by entering your API key directly in the dashboard Settings panel:
 
-- **OpenAI** (GPT-4o) -- enter your OpenAI API key
-- **Anthropic** (Claude) -- enter your Anthropic API key
+- **OpenAI** (GPT-4o): enter your OpenAI API key
+- **Anthropic** (Claude): enter your Anthropic API key
 
-No environment variables or external services needed. Simulated mode (default) works without any API keys — kill-chain progression in the Attack Lab will show static stages only; live progression requires an API key.
+No environment variables or external services needed. Simulated mode (default) works without any API keys; kill-chain progression in the Attack Lab will show static stages only, and live progression requires an API key.
 
 ## Web Dashboard
 
 The dashboard at `http://localhost:9000` includes six integrated views:
 
-- **Agents** — Grid of all 17 agents with live stats, security levels, and test commands
-- **Challenges** — CTF-style challenge board with 5,900 total points, progressive hints, and in-browser verification
-- **Attack Lab** — Interactive multi-step kill-chain walkthroughs (live progression requires LLM mode)
-- **Attack Log** — Real-time scrolling table of detected attacks with filters by agent, category, and result
-- **Stats** — Summary metrics, per-category bar chart, and sortable per-agent breakdown
-- **Prompt Playground** — Interactive security testing lab for system prompts
+- **Agents:** grid of all 19 agents with live stats, security levels, and test commands. Click a card to drill into its tools, declared vulnerabilities, and attack history.
+- **Challenges:** CTF-style challenge board with 5,900 total points, progressive hints, and in-browser verification.
+- **Attack Lab:** interactive multi-step kill-chain walkthroughs (live progression requires LLM mode).
+- **Attack Log:** real-time table of detected attacks. Click any row for the full payload, the agent response with leaked secrets highlighted, a What / Why / Defend explainer per category, and a "same payload vs SecureBot" command.
+- **Stats:** summary metrics, per-category bar chart, and sortable per-agent breakdown.
+- **Prompt Playground:** interactive security testing lab for system prompts.
 
 ### Prompt Playground
 
 Test your own system prompts against real security attacks:
 
-- **Attack Engine**: Test against 9+ attack patterns (prompt injection, jailbreak, data exfiltration, capability abuse, context manipulation)
-- **Real LLM Support**: Test with OpenAI GPT-4 or Anthropic Claude for production validation
-- **Simulated Mode**: Fast, free pattern-based testing for learning (default, recommended)
-- **AI Recommendations**: Get specific fixes for detected vulnerabilities
-- **One-Click Apply**: Automatically enhance prompts with security controls
-- **Best Practices Library**: Learn from 5 example prompts ranging from insecure to hardened
-- **Intensity Levels**: Passive (5 attacks), Active (9 attacks), Aggressive (all attacks)
-- **Score & Rating**: Overall security score (0-100) with detailed breakdown by category
+- **Attack Engine:** test against 9+ attack patterns (prompt injection, jailbreak, data exfiltration, capability abuse, context manipulation).
+- **Real LLM Support:** test with OpenAI GPT-4 or Anthropic Claude for production validation.
+- **Simulated Mode:** fast, free pattern-based testing for learning (default, recommended).
+- **AI Recommendations:** get specific fixes for detected vulnerabilities.
+- **One-Click Apply:** automatically enhance prompts with security controls.
+- **Best Practices Library:** learn from 5 example prompts ranging from insecure to hardened.
+- **Intensity Levels:** Passive (5 attacks), Active (9 attacks), Aggressive (all attacks).
+- **Score & Rating:** overall security score (0-100) with detailed breakdown by category.
 
 ## Agent Fleet
 
@@ -79,6 +79,8 @@ Test your own system prompts against real security attacks:
 | RAGBot-AIM | 7014 | AIM-protected | OpenAI API | Same code as RAGBot, capability grant enforced by AIM |
 | ResearchBot | 7015 | Weak | OpenAI API | Web-content prompt injection during research/browsing |
 | ResearchBot-AIM | 7016 | AIM-protected | OpenAI API | Same code as ResearchBot, outbound tool calls gated by AIM |
+| FlightBot | 7017 | Weak | OpenAI API | Indirect injection via web fetch, wallet exfiltration |
+| FlightBot-AIM | 7018 | AIM-protected | OpenAI API | Same code as FlightBot, egress gated by AIM capability grant |
 | VisionBot | 7006 | Weak | OpenAI API | Image-based prompt injection |
 | MemoryBot | 7007 | Vulnerable | OpenAI API | Memory injection, cross-session persistence |
 | LongwindBot | 7008 | Weak | OpenAI API | Context overflow, safety displacement |
@@ -96,7 +98,7 @@ Test your own system prompts against real security attacks:
 | 9000 | Web dashboard (agents, challenges, attack lab, log, stats, playground) |
 | 7001-7008 | OpenAI-compatible API agents (`/v1/chat/completions`) |
 | 7010-7013 | MCP tool servers (JSON-RPC at `/`, legacy at `/mcp/execute`) |
-| 7014-7016 | AIM-protected + research API agents (`/v1/chat/completions`) |
+| 7014-7018 | AIM-protected, research, and flight API agents (`/v1/chat/completions`) |
 | 7020-7021 | A2A agents (`/a2a/message`) |
 
 ## Vulnerability Categories
@@ -146,7 +148,7 @@ Key subcommands (all accept `--json` for CI):
 
 | | |
 |---|---|
-| `dvaa agents` | List all 17 agents with port, protocol, URL |
+| `dvaa agents` | List all 19 agents with port, protocol, URL |
 | `dvaa health` | Ping the dashboard; exit 1 if unreachable |
 | `dvaa attack <agent\|url>` | Run HMA attack suite (accepts agent name or URL) |
 | `dvaa logs [--follow]` | Tail the attack log |
@@ -155,7 +157,7 @@ Key subcommands (all accept `--json` for CI):
 | `dvaa hma <args…>` | Pass-through to the bundled HackMyAgent CLI |
 | `dvaa browse [url]` | Send DVAA agents to browse a target (agentpwn.com by default) |
 
-The image's default `CMD` starts every agent and the dashboard together — no `dvaa` invocation needed. The CLI is for scripting, CI, and the dev-workflow loop (spin up → attack → scan → fix → re-scan) from your host.
+The image's default `CMD` starts every agent and the dashboard together; no `dvaa` invocation needed. The CLI is for scripting, CI, and the dev-workflow loop (spin up, attack, scan, fix, re-scan) from your host.
 
 ## Environment Variables
 
@@ -167,21 +169,21 @@ The image's default `CMD` starts every agent and the dashboard together — no `
 
 ## Troubleshooting
 
-**Port 7001 (or similar) already in use.** Stop the conflicting service first — that's the simplest fix. If you can't, use `HOST_PORT_OFFSET` to shift every displayed port by a fixed amount:
+**Port 7001 (or similar) already in use.** Stop the conflicting service first; that's the simplest fix. If you can't, use `HOST_PORT_OFFSET` to shift every displayed port by a fixed amount:
 
 ```bash
-# Remap host ports 7001-7021 → 7501-7521. Container-internal ports stay unchanged.
+# Remap host ports 7001-7021 to 7501-7521. Container-internal ports stay unchanged.
 docker run -d -e HOST_PORT_OFFSET=500 \
   -p 9000:9000 \
-  -p 7501-7508:7001-7008 -p 7510-7516:7010-7016 -p 7520-7521:7020-7021 \
-  opena2a/dvaa:0.9.1
+  -p 7501-7521:7001-7021 \
+  opena2a/dvaa:0.9.2
 ```
 
 `HOST_PORT_OFFSET` affects only what the dashboard **displays** (test commands, agent URLs). The container still binds internally to `7001-7021`. Remapping with `-p 8001:7001` without setting the env var will leave the dashboard telling users to hit `7001` while the agent is actually on `8001`.
 
 ## Upgrading from v0.7.x
 
-- **Ports moved `3000` → `7000`.** Update any hardcoded URLs, HMA scan targets, CI scripts, or docker-compose overrides: `3001` → `7001`, `3010` → `7010`, `3020` → `7020`, etc. Dashboard is still `9000`.
+- **Ports moved `3000` to `7000`.** Update any hardcoded URLs, HMA scan targets, CI scripts, or docker-compose overrides: `3001` to `7001`, `3010` to `7010`, `3020` to `7020`, etc. Dashboard is still `9000`.
 - **`PORT_API_BASE`, `PORT_MCP_BASE`, `PORT_A2A_BASE` removed.** These were documented but never actually read by the server. Use `HOST_PORT_OFFSET` for custom port layouts.
 
 ## Links
@@ -195,4 +197,4 @@ docker run -d -e HOST_PORT_OFFSET=500 \
 
 ## License
 
-Apache-2.0 — For educational and authorized security testing only.
+Apache-2.0. For educational and authorized security testing only.


### PR DESCRIPTION
The Docker Hub page is sourced from `DOCKER_README.md` (not `README.md`) and was badly stale: 17 agents, `opena2a/dvaa:0.9.1`, the old 3-range port mapping that missed FlightBot, a port table without 7017-7018, and 14 em dashes.

- All-ports quick-start command on 0.9.2 (matches the README hero).
- 19 agents throughout; added FlightBot/FlightBot-AIM to the fleet + ports tables.
- Documented the attack-storytelling drawer + agent drill-down.
- Em-dash-free, including the Docker Hub short-description in the workflow.

Merging retriggers `docker-hub-description.yml` (paths filter on DOCKER_README.md), refreshing the Hub overview. No image rebuild needed; the image does not contain the README.